### PR TITLE
chore(*): fix typo in comments & add md5 dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.5",
     "markdown-it": "^8.4.2",
+    "md5": "^2.2.1",
     "minimist": "^1.2.0",
     "mocha": "^3.5.3",
     "moment": "^2.20.1",

--- a/src/util/string.js
+++ b/src/util/string.js
@@ -1,5 +1,5 @@
 /**
- * 将字符串转化为坨峰式写法
+ * 将字符串转化为驼峰式写法
  * @param  {String} str 例：-webkit-transition
  * @return {String}     例：WebkitTransition
  */
@@ -11,7 +11,7 @@ export function camelcase (str) {
 }
 
 /**
- * 将坨峰式字符串转化为连字符写法
+ * 将驼峰式字符串转化为连字符写法
  * @param  {String} str 例：WebkitTransition
  * @return {String}     例：-webkit-transition
  */


### PR DESCRIPTION
Hello, when I excute `npm run dev`, the terminal hints md5 module isn't install, so I add it into `package.json`:

![image](https://user-images.githubusercontent.com/8329568/47720394-c1ce8400-dc88-11e8-9d8c-fbc75d38e1fa.png)

Also, `npm run dev` script seems not to be compatible with git bash on windows 10, those markdown files under `/docs` can't be parsed correctly. Finally I have to use WSL to run this project.