### PR TITLE
fix(Upload): allow remove file when disabled

### DIFF
--- a/src/upload/upload.jsx
+++ b/src/upload/upload.jsx
@@ -357,10 +357,6 @@ class Upload extends Base {
      * @return {void}
      */
     removeFile = (file) => {
-        if (this.props.disabled) {
-            // disabled状态下不许删除文件
-            return;
-        }
         file.state = 'removed';
         this.uploaderRef.abort(file);     // 删除组件时调用组件的 `abort` 方法中断上传
 


### PR DESCRIPTION
When limit is set,  exceeding limit will cause upload disabled.

so disable delete file when disabled will result in failing delete file when reaching limit.

-----------

之前修复了一个bug,就是 禁止disable状态下删除文件。
但是后来发现, 在设置了limit以后,会触发组件disable。 
例如limit = 2的时候, 传了两个文件以后就不可以删除文件了。而现在很多线上的组件都是这么用的，所以先回滚这个特性。