### PR TITLE
fix(Table): style conflict with align

### DIFF
--- a/src/table/base/cell.jsx
+++ b/src/table/base/cell.jsx
@@ -50,6 +50,7 @@ export default class Cell extends React.Component {
         /* eslint-disable no-unused-vars */
         const {prefix, className, cell, value, resizable, colIndex, rowIndex, record, context, align, style = {}, component: Tag,
             children, title, width, innerStyle, primaryKey, __normalized, filterMode, filters, sortable, lock, pure, ...others} = this.props;
+        const tagStyle = {...style};
         const cellProps = {value, index: rowIndex, record, context};
         let content = cell;
         if (React.isValidElement(content)) {
@@ -58,14 +59,14 @@ export default class Cell extends React.Component {
             content = content(value, rowIndex, record, context);
         }
         if (align) {
-            style.textAlign = align;
+            tagStyle.textAlign = align;
         }
         const cls = classnames({
             [`${prefix}table-cell`]: true,
             [className]: className
         });
 
-        return (<Tag {...others} className={cls} style={style} role="gridcell">
+        return (<Tag {...others} className={cls} style={tagStyle} role="gridcell">
             <div className={`${prefix}table-cell-wrapper`} style={innerStyle}>
                 {content}
                 {children}


### PR DESCRIPTION
error occurs when set props 'style' and 'align' both on Table.Column.

![image](https://user-images.githubusercontent.com/18021913/50432232-5fea6d80-090b-11e9-8009-3e12fe93d9b2.png)
