### PR TITLE
fix(Loading): block style

### DIFF
--- a/src/loading/index.jsx
+++ b/src/loading/index.jsx
@@ -56,6 +56,10 @@ class Loading extends React.Component {
          * 子元素
          */
         children: PropTypes.any,
+        /**
+         * should loader be displayed inline
+         */
+        inline: PropTypes.bool
     };
 
     static defaultProps = {
@@ -65,6 +69,7 @@ class Loading extends React.Component {
         animate: null,
         tipAlign: 'bottom',
         size: 'large',
+        inline: true
     };
 
     render() {
@@ -80,7 +85,8 @@ class Loading extends React.Component {
             fullScreen,
             onVisibleChange,
             tipAlign,
-            size
+            size,
+            inline
         } = this.props;
 
         let indicatorDom = null;
@@ -105,6 +111,7 @@ class Loading extends React.Component {
         const loadingCls = classNames({
             [`${prefix}loading`]: true,
             [`${prefix}open`]: visible,
+            [`${prefix}loading-inline`]: inline,
             [className]: className
         });
 

--- a/src/loading/main.scss
+++ b/src/loading/main.scss
@@ -9,11 +9,11 @@
 
 #{$loading-prefix} {
     position: relative;
-    display: inline-block;
 
     &.#{$css-prefix}open {
         pointer-events: none;
     }
+
     /* 遮罩层 */
     #{$loading-prefix}-component {
         opacity: .7;
@@ -33,6 +33,10 @@
         z-index: 99;
         opacity: .2;
         background: #FFF;
+    }
+
+    &-inline {
+        display: inline-block;
     }
 
     &-tip {


### PR DESCRIPTION
- add `inline` property that sets Loading componet to `display: inline-block`
- `inline` defaults to true
- if `inline: false`, Loading component uses `div` default of `block`