### PR TITLE
fix(Tab): shallow rtl support

### DIFF
--- a/src/tab/tab.jsx
+++ b/src/tab/tab.jsx
@@ -250,6 +250,7 @@ export default class Tab extends Component {
 
         const navProps = {
             prefix,
+            rtl,
             animation,
             activeKey,
             excessMode,

--- a/src/tab/tabs/nav.jsx
+++ b/src/tab/tabs/nav.jsx
@@ -11,11 +11,13 @@ import { triggerEvents, getOffsetLT, getOffsetWH, isTransformSupported } from '.
 
 const noop = () => {};
 const floatRight = { float: 'right' };
+const floatLeft = { float: 'left' };
 const { Popup } = Overlay;
 
 class Nav extends React.Component {
     static propTypes = {
         prefix: PropTypes.string,
+        rtl: PropTypes.bool,
         animation: PropTypes.bool,
         activeKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         excessMode: PropTypes.string,
@@ -363,7 +365,7 @@ class Nav extends React.Component {
     }
 
     render() {
-        const { prefix, tabPosition, excessMode, extra, onKeyDown, animation, style, className } = this.props;
+        const { prefix, tabPosition, excessMode, extra, onKeyDown, animation, style, className, rtl } = this.props;
         const state = this.state;
 
         let nextButton;
@@ -441,7 +443,8 @@ class Nav extends React.Component {
                 key: 'nav-extra',
             };
             if (tabPosition === 'top' || tabPosition === 'bottom') {
-                navChildren.unshift(<div {...extraProps} style={floatRight}>{extra}</div>);
+                const style = rtl ? floatLeft : floatRight;
+                navChildren.unshift(<div {...extraProps} style={style}>{extra}</div>);
             } else {
                 navChildren.push(<div {...extraProps}>{extra}</div>);
             }


### PR DESCRIPTION
最好在下个Y位去掉，这里添加支持只是为了那些有可能升级js包，但是不升级样式包的用户，并且rtl的支持很有限，这里只是简单处理