### PR TITLE
[WIP] A11y unit tests and dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "power-assert": "^1.5.0",
     "promise-polyfill": "^8.1.0",
     "react": "^16.0.0",
+    "react-axe": "^3.0.2",
     "react-copy-to-clipboard": "^5.0.1",
     "react-cropper": "^1.0.0",
     "react-dev-utils": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@no-repeat/sassdoc-parser": "^0.0.11",
     "@octokit/rest": "^15.15.1",
     "autoprefixer": "^7.1.4",
+    "axe-core": "^3.1.2",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.3",
     "babel-loader": "^7.0.0",

--- a/scripts/server/loaders/demo/index.js
+++ b/scripts/server/loaders/demo/index.js
@@ -83,8 +83,19 @@ if (module.hot) {
     });
   }
 }`;
+    let reactAxe;
+    if (process.env.NODE_ENV !== 'production') {
+        reactAxe = `
+            // Load react-axe library for a11y testing during development
+            import React from 'react';
+            import ReactDOM from 'react-dom';
+            import Axe from 'react-axe';
+            
+            Axe(React, ReactDOM, 1000);
+            `;
+    }
 
-    return `${css ? getCSSRequireString(resourcePath, context) : ''}${js}${hotReloadCode}`;
+    return `${css ? getCSSRequireString(resourcePath, context) : ''}${js}${hotReloadCode}${reactAxe}`;
 }
 
 function getCSSRequireString(resourcePath, context) {

--- a/scripts/server/loaders/demo/index.js
+++ b/scripts/server/loaders/demo/index.js
@@ -45,10 +45,11 @@ module.exports = function(content) {
     });
 
     const result = parseMD(content, resourcePath, lang, dir);
-    return processJS(result.js, result.css, result.meta.desc, result.body, resourcePath, this.context, dir);
+    return processJS(result.js, result.css, result.meta.desc, result.body, resourcePath, this.context, dir, options);
 };
 
-function processJS(js, css, desc, body, resourcePath, context, dir) {
+function processJS(js, css, desc, body, resourcePath, context, dir, options) {
+    const { devA11y } = options;
     if (!js) {
         return '';
     }
@@ -84,7 +85,7 @@ if (module.hot) {
   }
 }`;
     let reactAxe;
-    if (process.env.NODE_ENV !== 'production') {
+    if (devA11y) {
         reactAxe = `
             // Load react-axe library for a11y testing during development
             import React from 'react';

--- a/scripts/server/server.js
+++ b/scripts/server/server.js
@@ -34,6 +34,7 @@ const port = parseInt(argv.port, 10);
 const componentName = argv._[0];
 const componentPath = path.join(process.cwd(), 'docs', componentName);
 const disableAnimation = argv['disable-animation'];
+const devA11y = argv.a11y;
 
 choosePort(host, port).then(tryToRun);
 
@@ -53,7 +54,8 @@ function run(port) {
         componentPath,
         disableAnimation,
         lang,
-        dir
+        dir,
+        devA11y
     });
     const compiler = webpack(config);
 

--- a/scripts/server/webpack.js
+++ b/scripts/server/webpack.js
@@ -15,7 +15,7 @@ const cwd = process.cwd();
 
 module.exports = function getWebpackConfig(options) {
     const config = getConfig();
-    const { componentName, componentPath, disableAnimation, lang, dir } = options;
+    const { componentName, componentPath, disableAnimation, lang, dir, devA11y } = options;
 
     const indexPath = path.join(componentPath, lang === 'zh' ? 'index.md' : 'index.en-us.md');
     const demoPaths = glob.sync(path.join(componentPath, 'demo', '*.md'));
@@ -98,7 +98,8 @@ module.exports = function getWebpackConfig(options) {
                 links,
                 disableAnimation,
                 lang,
-                dir
+                dir,
+                devA11y
             }
         }]
     });

--- a/test/progress/index-spec.js
+++ b/test/progress/index-spec.js
@@ -2,7 +2,9 @@ import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import assert from 'power-assert';
+import Axe from 'axe-core';
 import Progress from '../../src/progress/index';
+import '../../src/progress/style.js';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -63,6 +65,23 @@ describe('Line', () => {
             assert(wrapper.find('.next-progress-line-overlay-finishing').length === 1);
         });
     });
+
+    describe('a11y', () => {
+        it('should not have any violations', (done) => {
+            const div = document.createElement('div');
+            document.body.appendChild(div);
+            mount(<Progress percent={30} />, { attachTo: div });
+
+            Axe.run('.next-progress-line', {}, function(error, results) {
+                if (error) {
+                    return error;
+                }
+
+                assert(results.violations.length === 0);
+                done();
+            });
+        });
+    });
 });
 
 describe('Circle', () => {
@@ -109,6 +128,23 @@ describe('Circle', () => {
 
             wrapper.setProps({ percent: 90 });
             assert(wrapper.find('.next-progress-circle-overlay-finishing').length === 1);
+        });
+    });
+
+    describe('a11y', () => {
+        it('should not have any violations', (done) => {
+            const div = document.createElement('div');
+            document.body.appendChild(div);
+            mount(<Progress shape="circle" percent={30} />, { attachTo: div });
+
+            Axe.run('.next-progress-circle', {}, function(error, results) {
+                if (error) {
+                    return error;
+                }
+
+                assert(results.violations.length === 0);
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
There are 2 parts to this PR: unit tests and a11y check when running dev server

### Unit tests
- Uses `axe-core` library (same library used by Chrome DevTools)
- Must import styles directly to be able to test for things like color contrast
- Should have at least 1 test for each major component type
 - Ex. <Progress /> and <Progress shape="circle" /> are separate subcomponents and should each have their own test
- Unit tests will only test for major violations using `results.violations.length === 0`. The other test results are warnings or require manual checking. It would be good in the future to have such results included in CI reports.

### A11y for Dev Server
- uses `react-axe` which is built on `axe-core`
- has nice reporting to console