### PR TITLE
Run automated A11y tests with Axe-core during development

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "power-assert": "^1.5.0",
     "promise-polyfill": "^8.1.0",
     "react": "^16.0.0",
+    "react-axe": "^3.0.2",
     "react-copy-to-clipboard": "^5.0.1",
     "react-cropper": "^1.0.0",
     "react-dev-utils": "^4.2.1",

--- a/scripts/server/loaders/demo/index.js
+++ b/scripts/server/loaders/demo/index.js
@@ -83,8 +83,19 @@ if (module.hot) {
     });
   }
 }`;
+    let reactAxe;
+    if (process.env.NODE_ENV !== 'production') {
+        reactAxe = `
+            // Load react-axe library for a11y testing during development
+            import React from 'react';
+            import ReactDOM from 'react-dom';
+            import Axe from 'react-axe';
+            
+            Axe(React, ReactDOM, 1000);
+            `;
+    }
 
-    return `${css ? getCSSRequireString(resourcePath, context) : ''}${js}${hotReloadCode}`;
+    return `${css ? getCSSRequireString(resourcePath, context) : ''}${js}${hotReloadCode}${reactAxe}`;
 }
 
 function getCSSRequireString(resourcePath, context) {

--- a/scripts/server/loaders/demo/index.js
+++ b/scripts/server/loaders/demo/index.js
@@ -88,10 +88,7 @@ if (module.hot) {
     if (devA11y) {
         reactAxe = `
             // Load react-axe library for a11y testing during development
-            import React from 'react';
-            import ReactDOM from 'react-dom';
             import Axe from 'react-axe';
-            
             Axe(React, ReactDOM, 1000);
             `;
     }

--- a/scripts/server/loaders/demo/index.js
+++ b/scripts/server/loaders/demo/index.js
@@ -45,10 +45,11 @@ module.exports = function(content) {
     });
 
     const result = parseMD(content, resourcePath, lang, dir);
-    return processJS(result.js, result.css, result.meta.desc, result.body, resourcePath, this.context, dir);
+    return processJS(result.js, result.css, result.meta.desc, result.body, resourcePath, this.context, dir, options);
 };
 
-function processJS(js, css, desc, body, resourcePath, context, dir) {
+function processJS(js, css, desc, body, resourcePath, context, dir, options) {
+    const { devA11y } = options;
     if (!js) {
         return '';
     }
@@ -84,7 +85,7 @@ if (module.hot) {
   }
 }`;
     let reactAxe;
-    if (process.env.NODE_ENV !== 'production') {
+    if (devA11y) {
         reactAxe = `
             // Load react-axe library for a11y testing during development
             import React from 'react';

--- a/scripts/server/server.js
+++ b/scripts/server/server.js
@@ -34,6 +34,7 @@ const port = parseInt(argv.port, 10);
 const componentName = argv._[0];
 const componentPath = path.join(process.cwd(), 'docs', componentName);
 const disableAnimation = argv['disable-animation'];
+const devA11y = argv.a11y;
 
 choosePort(host, port).then(tryToRun);
 
@@ -53,7 +54,8 @@ function run(port) {
         componentPath,
         disableAnimation,
         lang,
-        dir
+        dir,
+        devA11y
     });
     const compiler = webpack(config);
 

--- a/scripts/server/webpack.js
+++ b/scripts/server/webpack.js
@@ -15,7 +15,7 @@ const cwd = process.cwd();
 
 module.exports = function getWebpackConfig(options) {
     const config = getConfig();
-    const { componentName, componentPath, disableAnimation, lang, dir } = options;
+    const { componentName, componentPath, disableAnimation, lang, dir, devA11y } = options;
 
     const indexPath = path.join(componentPath, lang === 'zh' ? 'index.md' : 'index.en-us.md');
     const demoPaths = glob.sync(path.join(componentPath, 'demo', '*.md'));
@@ -98,7 +98,8 @@ module.exports = function getWebpackConfig(options) {
                 links,
                 disableAnimation,
                 lang,
-                dir
+                dir,
+                devA11y
             }
         }]
     });


### PR DESCRIPTION
### A11y for Dev Server
- uses `react-axe` which is built on `axe-core`
- pass `a11y=true` after the component name to report a11y issues. Defaults to off
 - Ex. `npm run dev Button a11y=true`
 - Causes compile time to be much longer.
- has nice reporting to console