### PR TITLE
A11y unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@no-repeat/sassdoc-parser": "^0.0.11",
     "@octokit/rest": "^15.15.1",
     "autoprefixer": "^7.1.4",
+    "axe-core": "^3.1.2",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.3",
     "babel-loader": "^7.0.0",

--- a/test/progress/index-spec.js
+++ b/test/progress/index-spec.js
@@ -2,7 +2,9 @@ import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import assert from 'power-assert';
+import Axe from 'axe-core';
 import Progress from '../../src/progress/index';
+import '../../src/progress/style.js';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -63,6 +65,23 @@ describe('Line', () => {
             assert(wrapper.find('.next-progress-line-overlay-finishing').length === 1);
         });
     });
+
+    describe('a11y', () => {
+        it('should not have any violations', (done) => {
+            const div = document.createElement('div');
+            document.body.appendChild(div);
+            mount(<Progress percent={30} />, { attachTo: div });
+
+            Axe.run('.next-progress-line', {}, function(error, results) {
+                if (error) {
+                    return error;
+                }
+
+                assert(results.violations.length === 0);
+                done();
+            });
+        });
+    });
 });
 
 describe('Circle', () => {
@@ -109,6 +128,23 @@ describe('Circle', () => {
 
             wrapper.setProps({ percent: 90 });
             assert(wrapper.find('.next-progress-circle-overlay-finishing').length === 1);
+        });
+    });
+
+    describe('a11y', () => {
+        it('should not have any violations', (done) => {
+            const div = document.createElement('div');
+            document.body.appendChild(div);
+            mount(<Progress shape="circle" percent={30} />, { attachTo: div });
+
+            Axe.run('.next-progress-circle', {}, function(error, results) {
+                if (error) {
+                    return error;
+                }
+
+                assert(results.violations.length === 0);
+                done();
+            });
         });
     });
 });

--- a/test/util/a11y.js
+++ b/test/util/a11y.js
@@ -3,6 +3,8 @@ import assert from 'power-assert';
 import Axe from 'axe-core';
 import { mount } from 'enzyme';
 
+const divId = 'a11y-root';
+
 /**
  * Helper function for running a11y unit tests using axe-core
  *
@@ -12,12 +14,11 @@ import { mount } from 'enzyme';
  *                 {Boolean} `incomplete` - should test error if there was an incomplete test? (not recommended)
  *                 {Object} `rules` - set properties for rules
  */
-export default function (node, cb, options = {}) {
+const test = function (node, cb, options = {}) {
     const div = document.createElement('div');
-    const divId = 'a11y-root';
     div.id = divId;
     document.body.appendChild(div);
-    mount(node, { attachTo: div });
+    const wrapper = mount(node, { attachTo: div });
 
     // disable `color-contrast` test by default when failing on incomplete tests. Can be overriden by setting `options.rules`
     if (options.incomplete && !options.rules) {
@@ -36,4 +37,15 @@ export default function (node, cb, options = {}) {
         }
         cb();
     });
-}
+
+    return wrapper;
+};
+
+const afterEach = function () {
+    const div = document.querySelector(`#${divId}`);
+    if (div) {
+        div.remove();
+    }
+};
+
+export default { test, afterEach };

--- a/test/util/a11y.js
+++ b/test/util/a11y.js
@@ -1,0 +1,39 @@
+
+import assert from 'power-assert';
+import Axe from 'axe-core';
+import { mount } from 'enzyme';
+
+/**
+ * Helper function for running a11y unit tests using axe-core
+ *
+ * @param {ReactDOM Node} node - React element to mount and run axe-core tests on
+ * @param {function} cb - callback function to call on success (normally will be `done` function)
+ * @param {Object} options - options for axe tests
+ *                 {Boolean} `incomplete` - should test error if there was an incomplete test? (not recommended)
+ *                 {Object} `rules` - set properties for rules
+ */
+export default function (node, cb, options = {}) {
+    const div = document.createElement('div');
+    const divId = 'a11y-root';
+    div.id = divId;
+    document.body.appendChild(div);
+    mount(node, { attachTo: div });
+
+    // disable `color-contrast` test by default when failing on incomplete tests. Can be overriden by setting `options.rules`
+    if (options.incomplete && !options.rules) {
+        options.rules = {
+            'color-contrast': {
+                enabled: false
+            }
+        };
+    }
+
+    Axe.run(`#${divId}`, { rules: options.rules }, function(error, results) {
+        assert(!error);
+        assert(results.violations.length === 0);
+        if (options.incomplete) {
+            assert(results.incomplete.length === 0);
+        }
+        cb();
+    });
+}


### PR DESCRIPTION
### About
- Uses `axe-core` library (same library used by Chrome DevTools)
- Must import styles directly to be able to test for things like color contrast
- Unit tests will only test for major violations using `results.violations.length === 0`. The other test results are warnings or require manual checking. It would be good in the future to have such results included in CI reports.
- created a11y unit test util functions to make testing easier

### Future testing guidelines
- Should have at least 1 test for each major component type
 - Ex. <Progress /> and <Progress shape="circle" /> are separate subcomponents and should each have their own test

