### PR TITLE
fix(Search): disable not work

### DIFF
--- a/docs/search/index.en-us.md
+++ b/docs/search/index.en-us.md
@@ -40,3 +40,4 @@ search data in forms or pages.
 | popupContent       | custom popup menu                                                                                                                 | ReactNode     | -         |
 | visible            | popupContent is displayed                                                                                                                 | Boolean       | -         |
 | hasClear           | show clear text button                                                                                                                   | Boolean       | false     |
+| disabled           | disabled or not                                                                                                                   | Boolean       | false     |

--- a/docs/search/index.md
+++ b/docs/search/index.md
@@ -41,3 +41,4 @@
 | popupContent       | 自定义渲染的的下拉框                                                                                                                 | ReactNode     | -         |
 | visible            | 自定义渲染的的下拉框                                                                                                                 | Boolean       | -         |
 | hasClear           | 是否显示清除按钮                                                                                                                   | Boolean       | false     |
+| disabled           | 是否禁用                                                                                                                       | Boolean       | false     |

--- a/src/search/Search.jsx
+++ b/src/search/Search.jsx
@@ -109,8 +109,13 @@ class Search extends React.Component {
          * 是否显示清除按钮
          */
         hasClear: PropTypes.bool,
+        /**
+         * 是否禁用
+         */
+        disabled: PropTypes.bool,
         locale: PropTypes.object,
         rtl: PropTypes.bool,
+
     };
 
     static defaultProps = {
@@ -125,6 +130,7 @@ class Search extends React.Component {
         onSearch: func.noop,
         onFilterChange: func.noop,
         hasClear: false,
+        disabled: false,
     };
 
     constructor(props) {
@@ -151,6 +157,9 @@ class Search extends React.Component {
     }
 
     onChange = (value) => {
+        if (this.props.disabled) {
+            return;
+        }
         if (!('value' in this.props)) {
             this.setState({ value });
         }
@@ -159,10 +168,16 @@ class Search extends React.Component {
     };
 
     onSearch = () => {
+        if (this.props.disabled) {
+            return;
+        }
         this.props.onSearch(this.state.value, this.state.filterValue);
     };
 
     onFilterChange = (filterValue) => {
+        if (this.props.disabled) {
+            return;
+        }
         if (!('filterValue' in this.props)) {
             this.setState({ filterValue });
         }
@@ -171,6 +186,9 @@ class Search extends React.Component {
     };
 
     onKeyDown = (e) => {
+        if (this.props.disabled) {
+            return;
+        }
         if (e.keyCode !== KEYCODE.ENTER) {
             return;
         }
@@ -178,7 +196,7 @@ class Search extends React.Component {
     }
     render() {
         const {
-            shape, filter, hasIcon,
+            shape, filter, hasIcon, disabled,
             placeholder, type, className,
             style, size, prefix, searchText,
             dataSource, filterProps, buttonProps,
@@ -206,7 +224,7 @@ class Search extends React.Component {
                 [`${prefix}search-btn`]: true,
                 [buttonProps.className]: !!buttonProps.className
             });
-            searchBtn = (<Button  {...buttonProps} tabIndex="0" className={cls} onClick={this.onSearch} onKeyDown={this.onKeyDown}>
+            searchBtn = (<Button  {...buttonProps} tabIndex="0" className={cls} onClick={this.onSearch} onKeyDown={this.onKeyDown} disabled={disabled}>
                 {hasIcon ? <Icon type="search" /> : null}
                 {searchText ? <span className={`${prefix}search-btn-text`}>{searchText}</span> : null}
             </Button>);
@@ -219,6 +237,7 @@ class Search extends React.Component {
                     hasBorder={false}
                     dataSource={filter}
                     size={size}
+                    disabled={disabled}
                     value={this.state.filterValue}
                     onChange={this.onFilterChange}
                 />
@@ -246,6 +265,7 @@ class Search extends React.Component {
                 value={this.state.value}
                 onChange={this.onChange}
                 popupContent={popupContent}
+                disabled={disabled}
             />
         </Group>);
 

--- a/src/search/Search.jsx
+++ b/src/search/Search.jsx
@@ -157,9 +157,6 @@ class Search extends React.Component {
     }
 
     onChange = (value) => {
-        if (this.props.disabled) {
-            return;
-        }
         if (!('value' in this.props)) {
             this.setState({ value });
         }
@@ -175,9 +172,6 @@ class Search extends React.Component {
     };
 
     onFilterChange = (filterValue) => {
-        if (this.props.disabled) {
-            return;
-        }
         if (!('filterValue' in this.props)) {
             this.setState({ filterValue });
         }
@@ -218,7 +212,7 @@ class Search extends React.Component {
                 [`${prefix}search-icon`]: true,
                 [buttonProps.className]: !!buttonProps.className
             });
-            searchIcon = <Icon {...buttonProps} type="search" tabIndex="0" role="button" className={cls} onClick={this.onSearch} onKeyDown={this.onKeyDown}/>;
+            searchIcon = <Icon {...buttonProps} type="search" tabIndex="0" role="button" aria-disabled={disabled} className={cls} onClick={this.onSearch} onKeyDown={this.onKeyDown}/>;
         } else {
             const cls = classNames({
                 [`${prefix}search-btn`]: true,

--- a/test/search/index-spec.js
+++ b/test/search/index-spec.js
@@ -180,7 +180,6 @@ describe('Search', () => {
             wrapper = mount(<Search defaultValue={'123'} filter={filter} filterValue={FILTER_VALUE} onSearch={onSearch} />);
             assert(wrapper.find('.next-select-values em').text() === FILTER_VALUE);
             wrapper.find('button').simulate('click');
-
         });
 
         it('act in controlled way', (done) => {
@@ -215,6 +214,32 @@ describe('Search', () => {
 
             wrapper.setProps({ value: VALUE, filterValue: FILTER_VALUE });
             wrapper.find('button').simulate('click');
+        });
+        it('should support disabled', () => {
+            const onSearch = sinon.spy();
+            const onChange = sinon.spy();
+            wrapper = mount(<Search shape="simple" onSearch={onSearch} onChange={onChange} disabled/>);
+            wrapper.find('.next-icon').simulate('click');
+            assert(onSearch.notCalled);
+            wrapper.find('input').simulate('change', { target: { value: '20' } });
+            assert(onChange.notCalled);
+        });
+        it('should support enter key', () => {
+            const onSearch = sinon.spy();
+            wrapper = mount(<Search onSearch={onSearch} value="123"/>);
+            // 支持enter
+            wrapper.find('button').simulate('keyDown', {keyCode: 13});
+            assert(onSearch.calledOnce);
+            // 不支持非enter
+            wrapper.find('button').simulate('keyDown', {keyCode: 14});
+            assert(onSearch.calledOnce);
+        });
+        it('should support disable enter key', () => {
+            const onSearch = sinon.spy();
+            wrapper = mount(<Search disabled shape="simple" onSearch={onSearch} value="123"/>);
+            // 支持enter
+            wrapper.find('.next-icon').simulate('keyDown', {keyCode: 13});
+            assert(onSearch.notCalled);
         });
     });
 


### PR DESCRIPTION
When disabled props put on Search, the Input in will be disabled but the button and filter won't.
this pr fix it;

---
之前的版本,设置search的 disabled= true, search里面的input被disable,但是button没有被disable。现在修复这个问题