### PR TITLE
fix(Select): display text should not change while under controlled

### DIFF
--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -171,7 +171,7 @@ class Select extends Base {
             searchValue: 'searchValue' in props ? props.searchValue : '',
         });
 
-        // For cache choosen value
+        // because dataSource maybe updated while select a item, so we should cache choosen value's item
         this.valueDataSource = {
             valueDS: [],    // [{value,label}]
             mapValueDS: {}  // {value: {value,label}}
@@ -330,7 +330,7 @@ class Select extends Base {
 
         const { cacheValue, mode, hiddenSelected } = this.props;
 
-        // 非受控更新缓存map
+        // cache those value maybe not exists in dataSource
         if (cacheValue || mode === 'tag') {
             this.valueDataSource = itemObj;
         }
@@ -571,7 +571,11 @@ class Select extends Base {
 
         // get detail value
         if (!this.useDetailValue()) {
-            value = this.valueDataSource.valueDS;
+            if (value === this.valueDataSource.value) {
+                value = this.valueDataSource.valueDS;
+            } else {
+                value = getValueDataSource(value, this.valueDataSource.mapValueDS, this.dataStore.getMapDS()).valueDS;
+            }
         }
 
         if (mode === 'single') {

--- a/test/select/index-spec.js
+++ b/test/select/index-spec.js
@@ -108,6 +108,17 @@ describe('Select', () => {
         assert(wrapper.find('span.next-select em').text() === 'bbb');
     });
 
+    it('should not change text while under controlled', () => {
+        const dataSource = [{ label: 'xxx', value: 123 }, { label: 'empty', value: 0 }];
+        wrapper.setProps({
+            dataSource,
+            visible: true,
+            value: 0
+        });
+        ReactTestUtils.Simulate.click(document.querySelectorAll('.next-menu-item')[0]);
+        assert(wrapper.find('span.next-select em').text() === 'empty');
+    });
+
     it('should support not string value', (done) => {
         const dataSource = [{ label: 'xxx', value: 123 }, { label: 'empty', value: false }];
         const onChange = (value) => {


### PR DESCRIPTION
should not change display text, while under controlled

```
<Select id="basic-demo" value={'frank'} >
    <Option value="jack">Jack</Option>
    <Option value="frank">Frank</Option>
    <Option value="hugo">Hugo</Option>
</Select>
```

text should always be frank, while select options