### PR TITLE
fix(Util): DO NOT process any non-string type value

### DIFF
--- a/src/util/string.js
+++ b/src/util/string.js
@@ -19,10 +19,11 @@ export function camelcase (str) {
  * @return {String}     例：-webkit-transition
  */
 export function hyphenate (str) {
-    if (typeof str !== 'string') {
+    const strType = typeOf(str);
+    if (strType !== 'String') {
         warning(
             '[ hyphenate(str: string): string ] ' +
-            `Expected arguments[0] to be a string but get a ${typeOf(str)}.` +
+            `Expected arguments[0] to be a string but get a ${strType}.` +
             'It will return an empty string without any processing.'
         );
         return '';
@@ -37,10 +38,11 @@ export function hyphenate (str) {
  * @return {String}        例：
  */
 export function template (tpl, object = {}) {
-    if (typeof tpl !== 'string') {
+    const tplType = typeOf(tpl);
+    if (tplType !== 'String') {
         warning(
             '[ template(tpl: string, object: object): string ] ' +
-            `Expected arguments[0] to be a string but get a ${typeOf(tpl)}.` +
+            `Expected arguments[0] to be a string but get a ${tplType}.` +
             'It will return an empty string without any processing.'
         );
         return '';

--- a/src/util/string.js
+++ b/src/util/string.js
@@ -1,3 +1,6 @@
+import { warning } from './log';
+import { typeOf } from './object';
+
 /**
  * 将字符串转化为驼峰式写法
  * @param  {String} str 例：-webkit-transition
@@ -16,6 +19,14 @@ export function camelcase (str) {
  * @return {String}     例：-webkit-transition
  */
 export function hyphenate (str) {
+    if (typeof str !== 'string') {
+        warning(
+            '[ hyphenate(str: string): string ] ' +
+            `Expected arguments[0] to be a string but get a ${typeOf(str)}.` +
+            'It will return an empty string without any processing.'
+        );
+        return '';
+    }
     return str.replace(/([A-Z])/g, $0 => `-${$0.toLowerCase()}`);
 }
 
@@ -26,6 +37,15 @@ export function hyphenate (str) {
  * @return {String}        例：
  */
 export function template (tpl, object = {}) {
+    if (typeof tpl !== 'string') {
+        warning(
+            '[ template(tpl: string, object: object): string ] ' +
+            `Expected arguments[0] to be a string but get a ${typeOf(tpl)}.` +
+            'It will return an empty string without any processing.'
+        );
+        return '';
+    }
+
     return tpl.replace(/\{[a-z]*\}/g, (str) => {
         const key = str.substring(1, str.length - 1);
         return object[key] || '';

--- a/test/util/string-spec.js
+++ b/test/util/string-spec.js
@@ -15,6 +15,14 @@ describe('src/string.js', function() {
     assert(string.hyphenate('transitionDelay') === 'transition-delay');
   });
 
+  it('string.hyphenate(str) should return empty string if arg[0] is not a string', function () {
+    assert(string.hyphenate() === '');
+    assert(string.hyphenate(null) === '');
+    assert(string.hyphenate([]) === '');
+    assert(string.hyphenate({}) === '');
+    assert(string.hyphenate(function() {}) === '');
+  })
+
   it('camelcase can restore the result of hyphenate', function () {
     assert(string.camelcase(string.hyphenate('WebkitTransition')) === 'WebkitTransition');
   });
@@ -22,4 +30,12 @@ describe('src/string.js', function() {
   it('string.template(tpl, obj) should return correct string', function () {
     assert(string.template('当前{current}, 共{total}页', { total: 3, current: 1}) === '当前1, 共3页');
   });
+
+  it('string.template(tpl, obj) should return empty string if arg[0] is not a string', function () {
+    assert(string.template() === '');
+    assert(string.template(null) === '');
+    assert(string.template([]) === '');
+    assert(string.template({}) === '');
+    assert(string.template(function() {}) === '');
+  })
 });


### PR DESCRIPTION
## Purpose

This PR is trying to resolve some **BREAKCHANGE**-like problems that caused by new features from **1.12.0** release.

## Background

In **1.12.0**, there has a bunch of features was added for enhance component's accessibilities, and that 's amazing job by the **next** team. But, there has a few problems in actual use. Especially for library maintainers who depend on **next** library, these problems are fatal:

Some components added new i18n messages and process them for a11y props, but missing a check for i18n messages compatibility. I'm maintaining a library which manage i18n messages in a centralized service. These messages should be stable and only changed on necessary. But the messages that added by new release has broken the status quo.

https://github.com/alibaba-fusion/next/blame/build/1.12.0/src/pagination/pagination.jsx#L278

The line of codes above used a new message's definition which named `labelPrev`, and process it with `string.template()`. But there has no type-checking in the `string.template()`, and that will cause an error if `labelPrev` is not defined on messages. In this case, I have to update i18n messages on the dictionary service, and waiting for next release nervously which might take new message's definitions. It's more like a **BREAKCHANGE** than a new feature.

## Expected

NO effects when adding / removing message definition.