### PR TITLE
Test/progress a11y update

### DIFF
--- a/src/progress/view/progress-circle.jsx
+++ b/src/progress/view/progress-circle.jsx
@@ -103,7 +103,6 @@ export default class Circle extends Component {
             <div
                 className={wrapCls}
                 dir={rtl ? 'rtl' : undefined}
-                tabIndex="0"
                 role="progressbar"
                 aria-valuenow={percent}
                 aria-valuemin="0"

--- a/src/progress/view/progress-line.jsx
+++ b/src/progress/view/progress-line.jsx
@@ -47,7 +47,6 @@ export default class Line extends React.PureComponent {
         return (
             <div
                 dir={rtl ? 'rtl' : undefined}
-                tabIndex="0"
                 role="progressbar"
                 aria-valuenow={percent}
                 aria-valuemin="0"

--- a/test/progress/a11y-spec.js
+++ b/test/progress/a11y-spec.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import Progress from '../../src/progress/index';
+import '../../src/progress/style.js';
+import a11y from '../util/a11y';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+/* eslint-disable no-undef, react/jsx-filename-extension */
+describe('Progress A11y', () => {
+    let wrapper;
+
+    afterEach(() => {
+        if (wrapper) {
+            wrapper.unmount();
+            wrapper = null;
+        }
+        a11y.afterEach();
+    });
+
+    it('should not have any violations for Line Progress', (done) => {
+        wrapper = a11y.test(<Progress percent={30} />, done, { incomplete: true });
+    });
+
+    it('should not have any violations for Circle Progress', (done) => {
+        wrapper = a11y.test(<Progress shape="circle" percent={30} />, done, { incomplete: true });
+    });
+});

--- a/test/progress/index-spec.js
+++ b/test/progress/index-spec.js
@@ -2,9 +2,7 @@ import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import assert from 'power-assert';
-import Axe from 'axe-core';
 import Progress from '../../src/progress/index';
-import '../../src/progress/style.js';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -65,23 +63,6 @@ describe('Line', () => {
             assert(wrapper.find('.next-progress-line-overlay-finishing').length === 1);
         });
     });
-
-    describe('a11y', () => {
-        it('should not have any violations', (done) => {
-            const div = document.createElement('div');
-            document.body.appendChild(div);
-            mount(<Progress percent={30} />, { attachTo: div });
-
-            Axe.run('.next-progress-line', {}, function(error, results) {
-                if (error) {
-                    return error;
-                }
-
-                assert(results.violations.length === 0);
-                done();
-            });
-        });
-    });
 });
 
 describe('Circle', () => {
@@ -128,23 +109,6 @@ describe('Circle', () => {
 
             wrapper.setProps({ percent: 90 });
             assert(wrapper.find('.next-progress-circle-overlay-finishing').length === 1);
-        });
-    });
-
-    describe('a11y', () => {
-        it('should not have any violations', (done) => {
-            const div = document.createElement('div');
-            document.body.appendChild(div);
-            mount(<Progress shape="circle" percent={30} />, { attachTo: div });
-
-            Axe.run('.next-progress-circle', {}, function(error, results) {
-                if (error) {
-                    return error;
-                }
-
-                assert(results.violations.length === 0);
-                done();
-            });
         });
     });
 });


### PR DESCRIPTION
- remove tabindex because progress elements should not be focusable (see default progressbar implementation)
- move a11y tests to their own spec file
- update tests to use the new a11y util
