### PR TITLE
(WIP) A11y: Dialog unit tests and generic unit test utility functions

### DIFF
--- a/src/dialog/inner.jsx
+++ b/src/dialog/inner.jsx
@@ -52,7 +52,7 @@ export default class Inner extends Component {
         const { prefix, title } = this.props;
         if (title) {
             this.titleId = guid('dialog-title-');
-            return <div className={`${prefix}dialog-header`} id={this.titleId} ref={this.getNode.bind(this, 'headerNode')}>{title}</div>;
+            return <div className={`${prefix}dialog-header`} role="heading" id={this.titleId} ref={this.getNode.bind(this, 'headerNode')}>{title}</div>;
         }
         return null;
     }

--- a/test/dialog/a11y-spec.js
+++ b/test/dialog/a11y-spec.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import Enzyme, { mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import assert from 'power-assert';
+import Dialog from '../../src/dialog/index';
+import '../../src/dialog/style.js';
+import a11y from '../util/a11y';
+import isHeading from '../util/a11y/checks/isHeading';
+import isButton from '../util/a11y/checks/isButton';
+import roleType from '../util/a11y/checks/roleType';
+
+/* eslint-disable react/jsx-filename-extension */
+/* global describe it afterEach */
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('Dialog A11y', () => {
+    describe('Basic', () => {
+        let wrapper;
+
+        afterEach(() => {
+            if (wrapper && wrapper.unmount) {
+                wrapper.unmount();
+                wrapper = null;
+            }
+            a11y.afterEach();
+        });
+
+        it('should not have any violations', (done) => {
+            wrapper = a11y.test(<Dialog visible />, done);
+        });
+
+        it('should have accessible `close` button', () => {
+            wrapper = mount(<Dialog visible />);
+            assert(isButton('.next-dialog-close', wrapper));
+        });
+
+        // TODO: test dialog buttons for accessiblity
+
+        it('should have accessible dialog heading', () => {
+            wrapper = mount(<Dialog visible title="my heading"/>);
+            assert(isHeading(wrapper.find('.next-dialog-header')));
+        });
+
+        it('should have role dialog', () => {
+            wrapper = mount(<Dialog visible/>);
+            assert(roleType('dialog', wrapper.find('.next-dialog')));
+        });
+    });
+
+    describe('Show', () => {
+        let hide;
+
+        afterEach(() => {
+            if (hide && typeof hide === 'function') {
+                hide();
+                hide = null;
+            }
+        });
+
+        it('should have role `alertdialog` for alert dialog', () => {
+            hide = Dialog.alert({
+                title: 'Title',
+                content: 'Content',
+                animation: false
+            }).hide;
+            assert(roleType('alertdialog', document.querySelector('.next-dialog')));
+        });
+
+        it('should have role `alertdialog` for show dialog', () => {
+            hide = Dialog.show({
+                title: 'Title',
+                content: 'Content',
+                animation: false
+            }).hide;
+            assert(roleType('alertdialog', document.querySelector('.next-dialog')));
+        });
+
+        it('should have role `alertdialog` for confirm dialog', () => {
+            hide = Dialog.confirm({
+                title: 'Title',
+                content: 'Content',
+                animation: false
+            }).hide;
+            assert(roleType('alertdialog', document.querySelector('.next-dialog')));
+        });
+    });
+});
+

--- a/test/util/a11y/checks/isButton.js
+++ b/test/util/a11y/checks/isButton.js
@@ -1,0 +1,15 @@
+import tagName from './tagName';
+import roleType from './roleType';
+
+/**
+ * Test if the node is a button tag or has role=button
+ * @param { String || ReactWrapper || DOMComponent } nodeOrSelector - Either a component to query for the tag name, or a CSS selector to find the
+ *                  node using the `rootNode` param
+ * @param { ReactWrapper || DOMComponent } rootNode - (Optional) root node used to search for the desired node using the CSS selector from `nodeOrSelector`.
+ *                  Required if `nodeOrSelector` is a string.
+ * @returns { Boolean }
+ */
+
+export default function(nodeOrSelector, rootNode) {
+    return tagName('button', nodeOrSelector, rootNode) || roleType('button', nodeOrSelector, rootNode);
+}

--- a/test/util/a11y/checks/isHeading.js
+++ b/test/util/a11y/checks/isHeading.js
@@ -1,0 +1,15 @@
+import tagName from './tagName';
+import roleType from './roleType';
+
+/**
+ * Test if the node is an h* tag or has role=heading
+ * @param { String || ReactWrapper || DOMComponent } nodeOrSelector - Either a component to query for the tag name, or a CSS selector to find the
+ *                  node using the `rootNode` param
+ * @param { ReactWrapper || DOMComponent } rootNode - (Optional) root node used to search for the desired node using the CSS selector from `nodeOrSelector`.
+ *                  Required if `nodeOrSelector` is a string.
+ * @returns { Boolean }
+ */
+
+export default function(nodeOrSelector, rootNode) {
+    return tagName(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'], nodeOrSelector, rootNode) || roleType('heading', nodeOrSelector, rootNode);
+}

--- a/test/util/a11y/checks/roleType.js
+++ b/test/util/a11y/checks/roleType.js
@@ -1,0 +1,36 @@
+/**
+ * Test the `role` attribute of a node
+ * @param { Array || String } roleTypes - ARIA Roles values that are to be checked against the desired nodes
+ * @param { String || ReactWrapper || DOMComponent } nodeOrSelector - Either a component to query for the tag name, or a CSS selector to find the
+ *                  node using the `rootNode` param
+ * @param { ReactWrapper || DOMComponent } rootNode - (Optional) root node used to search for the desired node using the CSS selector from `nodeOrSelector`.
+ *                  Required if `nodeOrSelector` is a string.
+ * @returns { Boolean } Is the node's role attribute one of the values passed in `roleTypes`?
+ */
+
+export default function(roleTypes, nodeOrSelector, rootNode) {
+    if (!nodeOrSelector || !roleTypes) {
+        return false;
+    }
+
+    let node = nodeOrSelector;
+
+    if (typeof node === 'string') {
+        node = rootNode.find(node);
+    }
+
+    let role;
+
+    if (node.getDOMNode) {
+        role = node.getDOMNode().getAttribute('role');
+    } else if (node.getAttribute) {
+        role = node.getAttribute('role');
+    } else if (node.attr) {
+        role = node.attr('role');
+    }
+
+    roleTypes = Array.isArray(roleTypes) ? roleTypes : [roleTypes];
+    return role && roleTypes.some(r => {
+        return role.toLocaleLowerCase() === r.toLocaleLowerCase();
+    });
+}

--- a/test/util/a11y/checks/tagName.js
+++ b/test/util/a11y/checks/tagName.js
@@ -1,0 +1,29 @@
+/**
+ * Test the HTML tag of a node
+ * @param { Array || String } names - HTML Tag element names that are to be checked against the desired nodes
+ * @param { String || ReactWrapper || DOMComponent } nodeOrSelector - Either a component to query for the tag name, or a CSS selector to find the
+ *                  node using the `rootNode` param
+ * @param { ReactWrapper || DOMComponent } rootNode - (Optional) root node used to search for the desired node using the CSS selector from `nodeOrSelector`.
+ *                  Required if `nodeOrSelector` is a string.
+ * @returns { Boolean } Is the node one of the tag types passed in `names`?
+ */
+
+export default function(names, nodeOrSelector, rootNode) {
+    if (!nodeOrSelector || !names) {
+        return false;
+    }
+
+    let node = nodeOrSelector;
+
+    if (typeof node === 'string') {
+        node = rootNode.find(node);
+    }
+    if (node.getDOMNode) {
+        node = node.getDOMNode();
+    }
+
+    names = Array.isArray(names) ? names : [names];
+    return names.some(n => {
+        return node.tagName.toLocaleLowerCase() === n.toLocaleLowerCase();
+    });
+}


### PR DESCRIPTION
feat(Dialog): add heading role to dialog header div

test(*): helper utils for a11y unit testing
- devs will be able to create a11y unit tests based on what an element is supposed to be
- generic `tagName` and `roleType` checks
- composite `isButton` and `isHeading` checks that use `roleType` and `tagName`
- checks allow for selectors, or ReactWrapper, DOMComponents

test(Dialog): a11y tests
- use a11y util for general violations
- use new element checks for roles and semantic markup