### PR TITLE
Test: A11y - helper utils for a11y unit testing

### DIFF
--- a/test/collapse/a11y-spec.js
+++ b/test/collapse/a11y-spec.js
@@ -3,7 +3,7 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Collapse from '../../src/collapse/index';
 import '../../src/collapse/style';
-import a11y from '../util/a11y';
+import a11y from '../util/a11y/validate';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -22,7 +22,7 @@ describe('Collapse A11y', () => {
     });
 
     it('should not have any violations for children rendered component', (done) => {
-        wrapper = a11y.test(<Collapse>
+        wrapper = a11y.testReact(<Collapse>
             <Panel title="Pannel Title">
                 Pannel Content
             </Panel>
@@ -45,6 +45,6 @@ describe('Collapse A11y', () => {
                 content: 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.'
             }
         ];
-        wrapper = a11y.test(<Collapse dataSource={list} />, done, { incomplete: true });
+        wrapper = a11y.testReact(<Collapse dataSource={list} />, done, { incomplete: true });
     });
 });

--- a/test/progress/a11y-spec.js
+++ b/test/progress/a11y-spec.js
@@ -3,7 +3,7 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Progress from '../../src/progress/index';
 import '../../src/progress/style.js';
-import a11y from '../util/a11y';
+import a11y from '../util/a11y/validate';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -20,10 +20,10 @@ describe('Progress A11y', () => {
     });
 
     it('should not have any violations for Line Progress', (done) => {
-        wrapper = a11y.test(<Progress percent={30} />, done, { incomplete: true });
+        wrapper = a11y.testReact(<Progress percent={30} />, done, { incomplete: true });
     });
 
     it('should not have any violations for Circle Progress', (done) => {
-        wrapper = a11y.test(<Progress shape="circle" percent={30} />, done, { incomplete: true });
+        wrapper = a11y.testReact(<Progress shape="circle" percent={30} />, done, { incomplete: true });
     });
 });

--- a/test/util/a11y/checks.js
+++ b/test/util/a11y/checks.js
@@ -1,0 +1,99 @@
+/**
+ * Test the `role` attribute of a node
+ * @param { Array || String } roleTypes - ARIA Roles values that are to be checked against the desired nodes
+ * @param { String || ReactWrapper || DOMComponent } nodeOrSelector - Either a component to query for the tag name, or a CSS selector to find the
+ *                  node using the `rootNode` param
+ * @param { ReactWrapper || DOMComponent } rootNode - (Optional) root node used to search for the desired node using the CSS selector from `nodeOrSelector`.
+ *                  Required if `nodeOrSelector` is a string.
+ * @returns { Boolean } Is the node's role attribute one of the values passed in `roleTypes`?
+ */
+const roleType = function(roleTypes, nodeOrSelector, rootNode) {
+    if (!nodeOrSelector || !roleTypes) {
+        return false;
+    }
+
+    let node = nodeOrSelector;
+
+    if (typeof node === 'string') {
+        node = rootNode.find(node);
+    }
+
+    let role;
+
+    if (node.getDOMNode) {
+        role = node.getDOMNode().getAttribute('role');
+    } else if (node.getAttribute) {
+        role = node.getAttribute('role');
+    } else if (node.attr) {
+        role = node.attr('role');
+    }
+
+    roleTypes = Array.isArray(roleTypes) ? roleTypes : [roleTypes];
+    return role && roleTypes.some(r => {
+        return role.toLocaleLowerCase() === r.toLocaleLowerCase();
+    });
+};
+
+
+/**
+ * Test the HTML tag of a node
+ * @param { Array || String } names - HTML Tag element names that are to be checked against the desired nodes
+ * @param { String || ReactWrapper || DOMComponent } nodeOrSelector - Either a component to query for the tag name, or a CSS selector to find the
+ *                  node using the `rootNode` param
+ * @param { ReactWrapper || DOMComponent } rootNode - (Optional) root node used to search for the desired node using the CSS selector from `nodeOrSelector`.
+ *                  Required if `nodeOrSelector` is a string.
+ * @returns { Boolean } Is the node one of the tag types passed in `names`?
+ */
+const tagName = function(names, nodeOrSelector, rootNode) {
+    if (!nodeOrSelector || !names) {
+        return false;
+    }
+
+    let node = nodeOrSelector;
+
+    if (typeof node === 'string') {
+        node = rootNode.find(node);
+    }
+    if (node.getDOMNode) {
+        node = node.getDOMNode();
+    }
+
+    names = Array.isArray(names) ? names : [names];
+    return names.some(n => {
+        return node.tagName.toLocaleLowerCase() === n.toLocaleLowerCase();
+    });
+};
+
+
+/**
+ * Test if the node is an h* tag or has role=heading
+ * @param { String || ReactWrapper || DOMComponent } nodeOrSelector - Either a component to query for the tag name, or a CSS selector to find the
+ *                  node using the `rootNode` param
+ * @param { ReactWrapper || DOMComponent } rootNode - (Optional) root node used to search for the desired node using the CSS selector from `nodeOrSelector`.
+ *                  Required if `nodeOrSelector` is a string.
+ * @returns { Boolean }
+ */
+const isHeading = function(nodeOrSelector, rootNode) {
+    return tagName(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'], nodeOrSelector, rootNode) || roleType('heading', nodeOrSelector, rootNode);
+};
+
+
+/**
+ * Test if the node is a button tag or has role=button
+ * @param { String || ReactWrapper || DOMComponent } nodeOrSelector - Either a component to query for the tag name, or a CSS selector to find the
+ *                  node using the `rootNode` param
+ * @param { ReactWrapper || DOMComponent } rootNode - (Optional) root node used to search for the desired node using the CSS selector from `nodeOrSelector`.
+ *                  Required if `nodeOrSelector` is a string.
+ * @returns { Boolean }
+ */
+const isButton = function(nodeOrSelector, rootNode) {
+    return tagName('button', nodeOrSelector, rootNode) || roleType('button', nodeOrSelector, rootNode);
+};
+
+
+export default {
+    roleType,
+    tagName,
+    isButton,
+    isHeading
+};

--- a/test/util/a11y/validate.js
+++ b/test/util/a11y/validate.js
@@ -8,18 +8,13 @@ const divId = 'a11y-root';
 /**
  * Helper function for running a11y unit tests using axe-core
  *
- * @param {ReactDOM Node} node - React element to mount and run axe-core tests on
+ * @param {String} selector - css selector for element to test
  * @param {function} cb - callback function to call on success (normally will be `done` function)
  * @param {Object} options - options for axe tests
  *                 {Boolean} `incomplete` - should test error if there was an incomplete test? (not recommended)
  *                 {Object} `rules` - set properties for rules
  */
-const test = function (node, cb, options = {}) {
-    const div = document.createElement('div');
-    div.id = divId;
-    document.body.appendChild(div);
-    const wrapper = mount(node, { attachTo: div });
-
+const test = function (selector, cb, options) {
     // disable `color-contrast` test by default when failing on incomplete tests. Can be overriden by setting `options.rules`
     if (options.incomplete && !options.rules) {
         options.rules = {
@@ -29,7 +24,7 @@ const test = function (node, cb, options = {}) {
         };
     }
 
-    Axe.run(`#${divId}`, { rules: options.rules }, function(error, results) {
+    Axe.run(selector, { rules: options.rules }, function(error, results) {
         assert(!error);
 
         if (results.violations.length) {
@@ -48,9 +43,28 @@ const test = function (node, cb, options = {}) {
         }
         cb();
     });
+};
+
+/**
+ * Helper function for running a11y unit tests using axe-core
+ *
+ * @param {ReactDOM Element} node - React element to mount and run axe-core tests on
+ * @param {function} cb - callback function to call on success (normally will be `done` function)
+ * @param {Object} options - options for axe tests
+ *                 {Boolean} `incomplete` - should test error if there was an incomplete test? (not recommended)
+ *                 {Object} `rules` - set properties for rules
+ */
+const testReact = function (node, cb, options = {}) {
+    const div = document.createElement('div');
+    div.id = divId;
+    document.body.appendChild(div);
+    const wrapper = mount(node, { attachTo: div });
+
+    test(`#${divId}`, cb, options);
 
     return wrapper;
 };
+
 
 const afterEach = function () {
     const div = document.querySelector(`#${divId}`);
@@ -59,4 +73,4 @@ const afterEach = function () {
     }
 };
 
-export default { test, afterEach };
+export default { test, testReact, afterEach };


### PR DESCRIPTION
helper utils for a11y unit testing
- devs will be able to create a11y unit tests based on what an element is supposed to be
- generic `tagName` and `roleType` checks
- composite `isButton` and `isHeading` checks that use `roleType` and `tagName`
- checks allow for selectors, or ReactWrapper, DOMComponents
- allow axe tests to run on any dom node
- update existing tests to reflect the change
- move and rename `a11y.js` util to `validate.js`