### PR TITLE
feat(Field): api spliceArray to splice Array like name.{index} / api autoValidate=false to close onChange validate

### DIFF
--- a/docs/field/demo/dynamic.md
+++ b/docs/field/demo/dynamic.md
@@ -2,14 +2,14 @@
 
 - order: 6
 
-Input 的 name 必须全局唯一, 否则可能会出现串行的错误
+通过 `spliceArray` 可以删除数组格式 name (eg: name.{index}) 的数据, 并且自动订正其他 name 的 index - 1 问题
 
 :::lang=en-us
 # mix usage
 
 - order: 6
 
-name of Input must be unique
+by use `spliceArray` could delete array type keys (eg: name.{index}), and make larger keys auto -1
 :::
 ---
 
@@ -31,7 +31,6 @@ class Demo extends React.Component {
 
         this.field = new Field(this, {
             parseName: true,
-            autoUnmount: true
         });
     }
 
@@ -52,11 +51,11 @@ class Demo extends React.Component {
     removeItem(index) {
         const { tableSource } = this.state;
         tableSource.splice(index, 1);
+        this.field.spliceArray('name.{index}', index);
         this.setState({ tableSource });
     }
 
-    // name.${value} 全局唯一
-    input = (value) => <Input {...this.field.init(`name.${value}`, { initValue: value })} />;
+    input = (value, index) => <Input  {...this.field.init(`name.${index}`, { initValue: index })} />;
     delete = (value, index) => <Button warning onClick={this.removeItem.bind(this, index)}>delete</Button>;
 
     render() {
@@ -68,8 +67,8 @@ class Demo extends React.Component {
                     <Table.Column title="operation" cell={this.delete} width={100} />
                 </Table>
                 <div style={{ marginTop: 10 }}>
-                    <Button type="primary" onClick={this.getValues}>print</Button>
-                    <Button type="normal" onClick={this.add} style={{ marginLeft: 4 }}>Add</Button>
+                    <Button type="primary" onClick={this.getValues} >print</Button>
+                    <Button type="normal" onClick={this.add} style={{ marginLeft: 8 }}>Add</Button>
                 </div>
             </div>
         );
@@ -77,10 +76,4 @@ class Demo extends React.Component {
 }
 
 ReactDOM.render(<Demo />, mountNode);
-````
-
-````css
-.demo .next-btn {
-    margin-right: 5px;
-}
 ````

--- a/docs/field/demo/validator.md
+++ b/docs/field/demo/validator.md
@@ -105,11 +105,11 @@ class App extends React.Component {
             <br/>
             <br/>
 
-            <Input multiple maxLength={10} defaultValue=">3 and <10" {...init('textarea', {
+            <Input.TextArea placeholder=">3 and <10" {...init('textarea', {
                 rules: [{
                     required: true,
-                    min: 3,
-                    max: 10
+                    minLength: 3,
+                    maxLength: 10
                 }]
             })} />
             {this.field.getError('textarea') ?

--- a/docs/field/index.en-us.md
+++ b/docs/field/index.en-us.md
@@ -209,6 +209,7 @@ The api interface provided by the object after `new` (eg `myfield.getValues()`) 
 |getState | Judge check status | Function(name: String)| 'error' 'success' 'loading' '' | '' |
 | getNames | Get the key of all components | Function()| ||
 |remove | Delete the data of a certain control or a group of controls. After deletion, the validate/value associated with it will be cleared. | Function(name: String/String[])|
+| spliceArray  | delete data of name like name.{index} | Function(keyMatch: String, index: Number)|  |  |
 
 #### init
 ```

--- a/docs/field/index.en-us.md
+++ b/docs/field/index.en-us.md
@@ -187,6 +187,7 @@ Let myfield = new Field(this [,options]);
 |forceUpdate | Only the components of PureComponent are recommended to open this forced refresh function, which will cause performance problems (500 components as an example: the render will cost 700ms when it is turned on, and 400ms if it is turned off) | Boolean |false|
 | scrollToFirstError | scrolling field.validate scrolls to the first errored component, offsets if it is an integer | Boolean/Number |true|
 | autoUnmount | Automatically delete the Unmout element, if you want to keep the data can be set to false | Boolean |true|
+| autoValidate | Automatically validate while value changed | Boolean  |true|
 | values | initial value| Object ||
 
 #### API Interface
@@ -225,6 +226,7 @@ init(name, options, props)
 | options.rules | Checksum Rules | Array/Object | | | |
 | options.getValueFromEvent | custom way to get value from `onChange` event, generally do not need to set. Detailed usage see demo `custom data get` | Function(value, ...args) parameter order and components are exactly the same The | | | |
 |props | Component-defined events can be written here | Object | | | |
+| autoValidate | Automatically validate while value changed | Boolean  |true|
 
 return
 

--- a/docs/field/index.md
+++ b/docs/field/index.md
@@ -191,6 +191,7 @@ let myfield = new Field(this [,options]);
 | forceUpdate | 仅建议PureComponent的组件打开此强制刷新功能，会带来性能问题(500个组件为例：打开的时候render花费700ms, 关闭时候render花费400ms) | Boolean  |false|
 | scrollToFirstError | field.validate的时候滚动到第一个出错的组件, 如果是整数会进行偏移 | Boolean/Number  |true|
 | autoUnmount | 自动删除Unmout元素，如果想保留数据可以设置为false | Boolean  |true|
+| autoValidate | 是否修改数据的时候就自动触发校验 | Boolean  |true|
 | values | 初始化数据 | Object ||
 
 #### API接口
@@ -229,6 +230,7 @@ init(name, options, props)
 | options.rules | 校验规则 | Array/Object | | | |
 | options.getValueFromEvent | 自定义从`onChange`事件中获取value的方式，一般不需要设置. 详细用法查看demo `自定义数据获取` | Function(value,...args) 参数顺序和组件是完全一致的 | | | |
 | props | 组件自定义的事件可以写在这里  | Object | | | |
+| autoValidate | 是否修改数据的时候自动触发校验单个组件的校验 | Boolean  |true|
 
 返回值
 ```

--- a/docs/field/index.md
+++ b/docs/field/index.md
@@ -213,7 +213,7 @@ let myfield = new Field(this [,options]);
 | getState  | 判断校验状态 | Function(name: String)| 'error' 'success' 'loading' '' | '' |
 | getNames  | 获取所有组件的key | Function()|  |  |
 | remove  | 删除某一个或者一组控件的数据，删除后与之相关的validate/value都会被清空 | Function(name: String/String[])|  |  |
-
+| spliceArray  | 删除 name 是数组格式的数据, 并且自动处理其他 name 的数组错位问题 | Function(keyMatch: String, index: Number)|  |  |
 
 #### init
 ```

--- a/docs/field/index.md
+++ b/docs/field/index.md
@@ -191,7 +191,7 @@ let myfield = new Field(this [,options]);
 | forceUpdate | 仅建议PureComponent的组件打开此强制刷新功能，会带来性能问题(500个组件为例：打开的时候render花费700ms, 关闭时候render花费400ms) | Boolean  |false|
 | scrollToFirstError | field.validate的时候滚动到第一个出错的组件, 如果是整数会进行偏移 | Boolean/Number  |true|
 | autoUnmount | 自动删除Unmout元素，如果想保留数据可以设置为false | Boolean  |true|
-| autoValidate | 是否修改数据的时候就自动触发校验 | Boolean  |true|
+| autoValidate | 是否修改数据的时候就自动触发校验, 设为 false 后只能通过 validate() 来触发校验  | Boolean  |true|
 | values | 初始化数据 | Object ||
 
 #### API接口
@@ -230,7 +230,7 @@ init(name, options, props)
 | options.rules | 校验规则 | Array/Object | | | |
 | options.getValueFromEvent | 自定义从`onChange`事件中获取value的方式，一般不需要设置. 详细用法查看demo `自定义数据获取` | Function(value,...args) 参数顺序和组件是完全一致的 | | | |
 | props | 组件自定义的事件可以写在这里  | Object | | | |
-| autoValidate | 是否修改数据的时候自动触发校验单个组件的校验 | Boolean  |true|
+| autoValidate | 是否修改数据的时候自动触发校验单个组件的校验, 设为 false 后只能通过 validate() 来触发校验 | Boolean  |true|
 
 返回值
 ```

--- a/docs/form/index.en-us.md
+++ b/docs/form/index.en-us.md
@@ -80,6 +80,7 @@ Form layout, validation, data submission operations used.
 | formatMessage | custom error message for `format` | String | - |
 | formatTrigger | custom trigger mode for `format` | String/Array | - |
 | validator | [validation] custom validation function <br><br> **signature **:<br>Function() => void | Function | - |
+| autoValidate | validate while value changed | Boolean            | -     |
 
 ### Form.Reset
 

--- a/docs/form/index.md
+++ b/docs/form/index.md
@@ -81,6 +81,7 @@
 | formatTrigger       | format 自定义触发方式                                                                                                          | String/Array       | -     |
 | validator           | [表单校验] 自定义校验函数<br><br>**签名**:<br>Function() => void                                                                     | Function           | -     |
 | validatorTrigger    | validator 自定义触发方式                                                                                                       | String/Array       | -     |
+| autoValidate        | 是否修改数据时自动触发校验, 设为 false 后修改不会再触发校验 | Boolean            | -     |
 
 ### Form.Submit
 

--- a/docs/form/index.md
+++ b/docs/form/index.md
@@ -25,21 +25,21 @@
 
 ### Form
 
-| 参数             | 说明                                                                                                                                   | 类型       | 默认值                                                    |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------------------------ |
-| inline         | 内联表单                                                                                                                                 | Boolean  | -                                                      |
-| size           | 单个 Item 的 size 自定义，优先级高于 Form 的 size, 并且当组件与 Item 一起使用时，组件自身设置 size 属性无效。<br><br>**可选值**:<br>'large'(大)<br>'medium'(中)<br>'small'(小) | Enum     | 'medium'                                               |
-| labelAlign     | 标签的位置<br><br>**可选值**:<br>'top'(上)<br>'left'(左)<br>'inset'(内)                                                                         | Enum     | 'left'                                                 |
-| labelTextAlign | 标签的左右对齐方式<br><br>**可选值**:<br>'left'(左)<br>'right'(右)                                                                                 | Enum     | -                                                      |
-| field          | 经 `new Field(this)` 初始化后，直接传给 Form 即可 用到表单校验则不可忽略此项                                                                                  | any      | -                                                      |
-| saveField      | 保存 Form 自动生成的 field 对象<br><br>**签名**:<br>Function() => void                                                                          | Function | func.noop                                              |
-| labelCol       | 控制第一级 Item 的 labelCol                                                                                                                | Object   | -                                                      |
-| wrapperCol     | 控制第一级 Item 的 wrapperCol                                                                                                              | Object   | -                                                      |
-| onSubmit       | form内有 `htmlType="submit"` 的元素的时候会触发<br><br>**签名**:<br>Function() => void                                                            | Function | function preventDefault(e) {     e.preventDefault(); } |
-| children       | 子元素                                                                                                                                  | any      | -                                                      |
-| value          | 表单数值                                                                                                                                 | Object   | -                                                      |
-| onChange       | 表单变化回调<br><br>**签名**:<br>Function() => void                                                                                          | Function | func.noop                                              |
-| component      | 设置标签类型                                                                                                                               | String   | 'form'                                                 |
+| 参数             | 说明                                                                                                                                                                                                                                      | 类型       | 默认值                                                    |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------ |
+| inline         | 内联表单                                                                                                                                                                                                                                    | Boolean  | -                                                      |
+| size           | 单个 Item 的 size 自定义，优先级高于 Form 的 size, 并且当组件与 Item 一起使用时，组件自身设置 size 属性无效。<br><br>**可选值**:<br>'large'(大)<br>'medium'(中)<br>'small'(小)                                                                                                    | Enum     | 'medium'                                               |
+| labelAlign     | 标签的位置<br><br>**可选值**:<br>'top'(上)<br>'left'(左)<br>'inset'(内)                                                                                                                                                                            | Enum     | 'left'                                                 |
+| labelTextAlign | 标签的左右对齐方式<br><br>**可选值**:<br>'left'(左)<br>'right'(右)                                                                                                                                                                                    | Enum     | -                                                      |
+| field          | 经 `new Field(this)` 初始化后，直接传给 Form 即可 用到表单校验则不可忽略此项                                                                                                                                                                                     | any      | -                                                      |
+| saveField      | 保存 Form 自动生成的 field 对象<br><br>**签名**:<br>Function() => void                                                                                                                                                                             | Function | func.noop                                              |
+| labelCol       | 控制第一级 Item 的 labelCol                                                                                                                                                                                                                   | Object   | -                                                      |
+| wrapperCol     | 控制第一级 Item 的 wrapperCol                                                                                                                                                                                                                 | Object   | -                                                      |
+| onSubmit       | form内有 `htmlType="submit"` 的元素的时候会触发<br><br>**签名**:<br>Function() => void                                                                                                                                                               | Function | function preventDefault(e) {     e.preventDefault(); } |
+| children       | 子元素                                                                                                                                                                                                                                     | any      | -                                                      |
+| value          | 表单数值                                                                                                                                                                                                                                    | Object   | -                                                      |
+| onChange       | 表单变化回调<br><br>**签名**:<br>Function(values: Object, item: Object) => void<br>**参数**:<br>_values_: {Object} 表单数据<br>_item_: {Object} 详细<br>_item.name_: {String} 变化的组件名<br>_item.value_: {String} 变化的数据<br>_item.field_: {Object} field 实例 | Function | func.noop                                              |
+| component      | 设置标签类型                                                                                                                                                                                                                                  | String   | 'form'                                                 |
 
 ### Form.Item
 
@@ -81,7 +81,7 @@
 | formatTrigger       | format 自定义触发方式                                                                                                          | String/Array       | -     |
 | validator           | [表单校验] 自定义校验函数<br><br>**签名**:<br>Function() => void                                                                     | Function           | -     |
 | validatorTrigger    | validator 自定义触发方式                                                                                                       | String/Array       | -     |
-| autoValidate        | 是否修改数据时自动触发校验, 设为 false 后修改不会再触发校验 | Boolean            | -     |
+| autoValidate        | 是否修改数据时自动触发校验                                                                                                           | Boolean            | -     |
 
 ### Form.Submit
 

--- a/src/form/enhance.jsx
+++ b/src/form/enhance.jsx
@@ -92,6 +92,7 @@ export function getFieldInitCfg(props, displayName) {
     return {
         valueName: getValueName(props, displayName),
         trigger: props.trigger ? props.trigger : 'onChange',
+        autoValidate: props.autoValidate,
         rules: getRules(props)
     };
 }

--- a/src/form/form.jsx
+++ b/src/form/form.jsx
@@ -83,6 +83,11 @@ export default class Form extends React.Component {
         value: PropTypes.object,
         /**
          * 表单变化回调
+         * @param {Object} values 表单数据
+         * @param {Object} item 详细
+         * @param {String} item.name 变化的组件名
+         * @param {String} item.value 变化的数据
+         * @param {Object} item.field field 实例
          */
         onChange: PropTypes.func,
         /**

--- a/src/form/item.jsx
+++ b/src/form/item.jsx
@@ -165,7 +165,11 @@ export default class Item extends React.Component {
         /**
          * validator 自定义触发方式
          */
-        validatorTrigger: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
+        validatorTrigger: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+        /**
+         * 是否修改数据时自动触发校验
+         */
+        autoValidate: PropTypes.bool,
     };
 
     static defaultProps = {

--- a/test/field/index-spec.js
+++ b/test/field/index-spec.js
@@ -295,7 +295,7 @@ describe('field', () => {
             assert(field.getError('input') === null);
             assert(field.getError('input2')[0] === "error 2");
 
-            field.setError('input', < span > hello < /span>);
+            field.setError('input', <span>hello</span>);
             assert(React.isValidElement(field.getError('input')[0]) === true);
 
             done();
@@ -383,6 +383,25 @@ describe('field', () => {
             field.remove(['input', 'input2']);
             assert(field._get('input') === null);
             assert(field._get('input2') === null);
+
+            done();
+        });
+        it('spliceArray', (done) => {
+            let field = new Field();
+            field.init('input.0', {initValue: 0});
+            field.init('input.1', {initValue: 1});
+            field.init('input.2', {initValue: 2});
+
+            field.spliceArray('input.{index}', 1);
+
+            assert(field.getValue('input.0') === 0);
+            assert(field.getValue('input.1') === 2);
+            assert(field.getValue('input.2') === undefined);
+
+            field.spliceArray('input.{index}', 0);
+            assert(field.getValue('input.0') === 2);
+            assert(field.getValue('input.1') === undefined);
+            assert(field.getValue('input.2') === undefined);
 
             done();
         });

--- a/test/field/options-spec.js
+++ b/test/field/options-spec.js
@@ -20,9 +20,9 @@ describe('options', () => {
                 const init = this.field.init;
                 return (
                     <div>
-                        <Input {...init('input')}/> {this.state.show
-                        ? < Input { ...init('input2')
-                                  } /> : null}
+                        <Input {...init('input')}/> {this.state.show ?
+                            < Input {...init('input2')
+                            } /> : null}
                         <button onClick={() => {
                             assert('input2' in this.field.getValues() === false);
                             done();
@@ -50,8 +50,8 @@ describe('options', () => {
                 const init = this.field.init;
                 return (
                     <div>
-                        {this.state.show
-                        ? < Input { ...init('input') } key="1"/> : <Input {...init('input')} key="2"/>}
+                        {this.state.show ?
+                            < Input {...init('input')} key="1"/> : <Input {...init('input')} key="2"/>}
                         <button onClick={() => {
                             assert('input' in this.field.getValues() === true);
                         }}>click
@@ -66,14 +66,14 @@ describe('options', () => {
 
         done();
     });
-    
+
     it('should support autoUnmount=false', (done) => {
 
         class Demo extends React.Component {
             state = {
                 show: true
             }
-            field = new Field(this, {autoUnmount:false});
+            field = new Field(this, {autoUnmount: false});
 
             render() {
                 const init = this.field.init;
@@ -82,7 +82,7 @@ describe('options', () => {
                         <Input {...init('input')}/>
                         {this.state.show ? < Input {...init('input2', {initValue: 'test2'})} /> : null}
                         <button onClick={() => {
-                            console.log(this.field)
+                            console.log(this.field);
                             assert(this.field.getValue('input2') === 'test2');
                         }}>click
                         </button>
@@ -111,7 +111,7 @@ describe('options', () => {
                         <Input {...init('input', {rules: [{required: true, message: 'cant be null'}]})}/>
                         <button onClick={() => {
                             this.field.validate((error, value, cb) => {
-                                assert(error['input']['errors'][0] === 'cant be null');
+                                assert(error.input.errors[0] === 'cant be null');
                             });
                         }}>click
                         </button>
@@ -157,13 +157,13 @@ describe('options', () => {
 
     describe('should support parseName', () => {
         it('getValues', (done) => {
-            let field = new Field(null, {parseName: true});
+            const field = new Field(null, {parseName: true});
             field.init('user.name', {initValue: 'frankqian'});
             field.init('user.pwd', {initValue: 12345});
             field.init('option[0]', {initValue: 'option1'});
             field.init('option[1]', {initValue: 'option2'});
 
-            let values = field.getValues();
+            const values = field.getValues();
 
             assert(Object.keys(values).length === 2);
             assert(values.user.name === 'frankqian');
@@ -175,7 +175,7 @@ describe('options', () => {
             done();
         });
         it('setValues', (done) => {
-            let field = new Field(null, {parseName: true});
+            const field = new Field(null, {parseName: true});
             field.init('user.name', {initValue: 'frankqian'});
             field.init('user.pwd', {initValue: 12345});
             field.init('option[0]', {initValue: 'option1'});
@@ -188,7 +188,7 @@ describe('options', () => {
                 option: ['test1', 'test2']
             });
 
-            let values = field.getValues();
+            const values = field.getValues();
 
             assert(Object.keys(values).length === 2);
 
@@ -199,4 +199,59 @@ describe('options', () => {
             done();
         });
     });
+
+    describe('should support autoValidate=false', () => {
+        it('options.autoValidate=true', (done) => {
+            const field = new Field(null, {autoValidate: true});
+            const inited = field.init('input', {rules: [{ minLength: 10 }]});
+
+            const wrapper = mount(<Input {...inited}/>);
+            wrapper.find('input').simulate('change', {
+                target: {
+                    value: 'test'
+                }
+            });
+
+            assert(field.getError('input') !== null);
+
+            done();
+        });
+        it('options.autoValidate=false', (done) => {
+            const field = new Field(null, {autoValidate: false});
+            const inited = field.init('input', {rules: [{ minLength: 10 }]});
+
+            const wrapper = mount(<Input {...inited}/>);
+            wrapper.find('input').simulate('change', {
+                target: {
+                    value: 'test'
+                }
+            });
+
+            assert(field.getError('input') === null);
+
+            field.validate('input');
+            assert(field.getError('input') !== null);
+
+            done();
+        });
+        it('props.autoValidate=false', (done) => {
+            const field = new Field(null);
+            const inited = field.init('input', {autoValidate: false, rules: [{ minLength: 10 }]});
+
+            const wrapper = mount(<Input {...inited}/>);
+            wrapper.find('input').simulate('change', {
+                target: {
+                    value: 'test'
+                }
+            });
+
+            assert(field.getError('input') === null);
+
+            field.validate('input');
+            assert(field.getError('input') !== null);
+
+            done();
+        });
+    });
+
 });

--- a/test/form/validate-spec.js
+++ b/test/form/validate-spec.js
@@ -120,6 +120,25 @@ describe('Submit', () => {
         assert(wrapper.find('.next-form-item-help').first().text() === 'first 是必填字段');
         wrapper.find('button').simulate('click');
     });
+
+    it('autoValidate=false', (done) => {
+        const onClick = (v) => {
+            assert(v.first === '');
+            done()
+        }
+        const wrapper = mount(<Form>
+            <FormItem minLength={10} autoValidate={false}>
+                <Input name="first"/>
+            </FormItem>
+            <Submit validate={['first']} onClick={onClick}>click</Submit>
+        </Form>);
+
+        wrapper.find('input#first').simulate('change', {target: {value: ""}});
+        wrapper.update();
+        assert(wrapper.find('.next-form-item-help').first().length === 0);
+        wrapper.find('button').simulate('click');
+        assert(wrapper.find('.next-form-item-help').first().text() === 'first 是必填字段');
+    });
 });
 
 describe('Reset', () => {


### PR DESCRIPTION
1. 处理 parseName 后数组删除后数据错位的问题，老版本必须指定全局唯一key，现在通过spliceArray来删除一个类似name.{index} 的key后，其他的key会自动 -1 来订正数组序列。


To deal with the problem of data misalignment after deletion of arrays.
in old version it must  to specify a global unique key.  Now, after deleting a key similar to name. {index} through spliceArray, the other keys will automatically - 1 to correct the array sequence.


value like

```
a.0 = 0
a.1 = 1
a.2 = 2
```

after delete a.0 by remove('a.0')

```
a.1 = 1
a.2 = 2
```

after delete a.0 by spliceArray('a.{index}', 0)

```
a.0 = 1
a.1 = 2
```

2. autoValidate=false 关闭自动校验 / use autoValidate=false to close auto validate by onChange

useg:

for all components
```
field = new Field(this, {autoValidate: false})
```
for single component
```
field = new Field(this)
field.init('name', {autoValidate: false});
```