### PR TITLE
fix(Table): correct index in expandedRowRender and getExpandedColProps

### DIFF
--- a/src/table/expanded.jsx
+++ b/src/table/expanded.jsx
@@ -110,7 +110,7 @@ export default function expanded(BaseComponent) {
                 switchNode = hasExpanded ?
                     <Icon type="minus" size="xs" /> : <Icon type="add" size="xs" />,
 
-                attrs = getExpandedColProps(record, index) || {};
+                attrs = getExpandedColProps(record, index / 2) || {};
             const cls = classnames({
                 [`${prefix}table-expanded-ctrl`]: true,
                 disabled: attrs.disabled,

--- a/src/table/expanded/row.jsx
+++ b/src/table/expanded/row.jsx
@@ -52,7 +52,7 @@ export default class ExpandedRow extends React.Component {
                     </tr> : null
                 );
             }
-            content = expandedRowRender(record, index);
+            content = expandedRowRender(record, (index - 1) / 2);
             if (!React.isValidElement(content)) {
                 content = (
                     <div className={`${prefix}table-cell-wrapper`}>

--- a/test/table/index-spec.js
+++ b/test/table/index-spec.js
@@ -188,14 +188,22 @@ describe('Table', () => {
 
     it('should support expandedRowRender', (done) => {
         timeout({
-            expandedRowRender: (record) => record.name
+            expandedRowRender: (record, index) => record.name + index,
+            getExpandedColProps: (record, index) => {
+                assert(record.id == index + 1);
+            }
         }, () => {
-            let expandedCtrl = wrapper.find('.next-table-body .next-table-expanded-ctrl').first();
+            let expandedCtrl0 = wrapper.find('.next-table-body .next-table-expanded-ctrl').at(0);
+            expandedCtrl0.simulate('click');
+            let expandedRow0 = wrapper.find('.next-table-body .next-table-expanded-row').at(0);
 
-            expandedCtrl.simulate('click');
+            assert(expandedRow0.text().replace(/\s$|^\s/g, '') === 'test' + '0');
 
-            let expandedRow = wrapper.find('.next-table-body .next-table-expanded-row').first();
-            assert(expandedRow.text().replace(/\s$|^\s/g, '') === 'test');
+            let expandedCtrl1 = wrapper.find('.next-table-body .next-table-expanded-ctrl').at(1);
+            expandedCtrl1.simulate('click');
+            let expandedRow1 = wrapper.find('.next-table-body .next-table-expanded-row').at(1);
+
+            assert(expandedRow1.text().replace(/\s$|^\s/g, '') === 'test2' + '1');
 
         }).then(() => {
             return timeout({


### PR DESCRIPTION
这两个函数里的index增长步长是2，应该是1。
具体表现是函数里的index打印出来是0，2，4，6，期望是1，2，3，4，看起来是0.x到1.x迁移引起的
原因在这一行 https://github.com/alibaba-fusion/next/blob/master/src/table/expanded.jsx#L169

close https://github.com/alibaba-fusion/next/issues/318