### PR TITLE
fix(*): use offset when positioning overlay, do not adjust range tooltip

### DIFF
--- a/src/message/main.scss
+++ b/src/message/main.scss
@@ -9,11 +9,6 @@
     @include box-sizing;
     @include message-bounding();
 
-    .#{$css-prefix}message-wrapper {
-        position: fixed;
-        left: 50%;
-    }
-
     .#{$css-prefix}message-close {
         color: $message-close-icon-color;
         font-size: 0;

--- a/src/overlay/utils/position.js
+++ b/src/overlay/utils/position.js
@@ -110,10 +110,10 @@ export default class Position {
             }
         }
 
+        // This will only execute if `pinElement` could not be placed entirely in the Viewport
         const inViewportLeft = this._makeElementInViewport(pinElement, firstPositionResult.left, 'Left', isPinFixed);
         const inViewportTop = this._makeElementInViewport(pinElement, firstPositionResult.top, 'Top', isPinFixed);
-
-        this._setPinElementPostion(pinElement, {left: inViewportLeft, top: inViewportTop});
+        this._setPinElementPostion(pinElement, { left: inViewportLeft, right: inViewportTop }, this.offset);
         return expectedAlign[0];
     }
 
@@ -244,7 +244,6 @@ export default class Position {
     _getExpectedAlign() {
         const align = this.isRtl ? this._replaceAlignDir(this.align, /l|r/g, {l: 'r', r: 'l'}) : this.align;
         const expectedAlign = [align];
-
         if (this.needAdjust) {
             if (/t|b/g.test(align)) {
                 expectedAlign.push(this._replaceAlignDir(align, /t|b/g, {t: 'b', b: 't'}));

--- a/src/range/view/range.jsx
+++ b/src/range/view/range.jsx
@@ -27,7 +27,8 @@ function LowerSlider(props) {
             popupProps={{
                 visible: tooltipVisible,
                 onVisibleChange: onTooltipVisibleChange,
-                animation: tooltipAnimation
+                animation: tooltipAnimation,
+                needAdjust: false
             }}
             trigger={Slider({ ...props, value: value[0] })}
             align="t"
@@ -63,7 +64,8 @@ function UpperSlider(props) {
                 popupProps={{
                     visible: tooltipVisible,
                     onVisibleChange: onTooltipVisibleChange,
-                    animation: tooltipAnimation
+                    animation: tooltipAnimation,
+                    needAdjust: false
                 }}
                 trigger={Slider({ ...newprop, value: value[1] })}
                 align="t"
@@ -78,7 +80,8 @@ function UpperSlider(props) {
             popupProps={{
                 visible: tooltipVisible,
                 onVisibleChange: onTooltipVisibleChange,
-                animation: tooltipAnimation
+                animation: tooltipAnimation,
+                needAdjust: false
             }}
             animation={{
                 in: 'fadeInUp',


### PR DESCRIPTION
- Positioned `Overlay` components should always use offsets if given. 
- Range Tooltips should not attempt to adjust the tooltip location to remain in the viewport
- Message fixed styles are not needed anywhere in the code base as no `.next-message` class has a nested `.next-message-wrapper` class. 