### PR TITLE
Feat/error boundary

### DIFF
--- a/docs/config-provider/demo/error-boundary.md
+++ b/docs/config-provider/demo/error-boundary.md
@@ -1,0 +1,80 @@
+# ErrorBoundary 捕获错误
+
+- order: 5
+
+使用 `<ErrorBoundary>` 可以避免由于局部区域的错误，所引起的页面白屏。
+
+:::lang=en-us
+# Basic
+
+- order: 5
+
+`<ErrorBoundary>` can be used to avoid blank screen caused by local errors
+:::
+
+---
+
+````jsx
+import { ConfigProvider, Button } from '@alifd/next';
+
+const { ErrorBoundary, config } = ConfigProvider;
+
+class Demo extends React.Component {
+    render() {
+        return (
+            <span>{this.props.locale.ok}</span>
+        );
+    }
+}
+
+const NewDemo = config(Demo);
+
+const fallbackUI = (props) => {
+    const { error, errorInfo } = props;
+    return <span style={{color: 'red'}}>Error: {error.toString()}</span>;
+};
+
+export default class App extends React.Component {
+    state = {
+        locale: {
+            ok: 'ok'
+        }
+    };
+
+    onClick = () => {
+        this.setState({
+            locale: undefined
+        });
+    };
+
+    render() {
+        return <div>
+            Pass undefined to locale which will cause an error: <Button type="primary" onClick={this.onClick}>trigger error</Button>
+            <br/>
+            <br/>
+            Default fallback UI:
+            <hr />
+            <ConfigProvider errorBoundary>
+                <NewDemo locale={this.state.locale}/>
+            </ConfigProvider>
+            <br/>
+            <br/>
+            Customize fallback UI of configed Component(Basic Components / Biz Components):
+            <hr />
+            <ConfigProvider errorBoundary={{
+                fallbackUI: props => {
+                    const { error, errorInfo } = props;
+                    return <span style={{color: 'red'}}>Error: {error.toString()}</span>;
+                },
+                afterCatch: () => {
+                    console.log('catching');
+                }
+            }}>
+                <NewDemo locale={this.state.locale}/>
+            </ConfigProvider>
+        </div>
+    }
+}
+
+ReactDOM.render(<App />, mountNode);
+````

--- a/docs/config-provider/index.en-us.md
+++ b/docs/config-provider/index.en-us.md
@@ -149,6 +149,7 @@ export default config(Component);
 
 | Param           | Description                                | Type       | Default Value          |
 | -------- | ----------------------------------- | ------------ | --- |
+| errorBoundary | turn errorBoundary on or not<br>If you pass object, properties：<br><br>fallbackUI `Function(error?: {}, errorInfo?: {}) => Element` <br>afterCatch `Function(error?: {}, errorInfo?: {})` after being catched, e.g. send data to server for data statistics | Boolean/Object | false |
 | pure     | whether enable the Pure Render mode, it will improve performance, but it will also have side effects | Boolean      | -   |
 | warning  | whether to display the warning prompt for component properties being deprecated in development mode        | Boolean      | true  |
 | children | component tree                                 | ReactElement | -   |

--- a/docs/config-provider/index.md
+++ b/docs/config-provider/index.md
@@ -214,12 +214,13 @@ export default config(Component);
 
 ### ConfigProvider
 
-| 参数       | 说明                                  | 类型           | 默认值  |
-| -------- | ----------------------------------- | ------------ | ---- |
-| pure     | 是否开启 Pure Render 模式，会提高性能，但是也会带来副作用 | Boolean      | -    |
-| warning  | 是否在开发模式下显示组件属性被废弃的 warning 提示       | Boolean      | true |
-| rtl      | 是否开启 rtl 模式                         | Boolean      | -    |
-| children | 组件树                                 | ReactElement | -    |
+| 参数            | 说明                                                                                                                                                                                                     | 类型             | 默认值   |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ----- |
+| errorBoundary | 是否开启错误捕捉 errorBoundary<br>如需自定义参数，请传入对象 对象接受参数列表如下：<br><br>fallbackUI `Function(error?: {}, errorInfo?: {}) => Element` 捕获错误后的展示<br>afterCatch `Function(error?: {}, errorInfo?: {})` 捕获错误后的行为, 比如埋点上传 | Boolean/Object | false |
+| pure          | 是否开启 Pure Render 模式，会提高性能，但是也会带来副作用                                                                                                                                                                    | Boolean        | -     |
+| warning       | 是否在开发模式下显示组件属性被废弃的 warning 提示                                                                                                                                                                          | Boolean        | true  |
+| rtl           | 是否开启 rtl 模式                                                                                                                                                                                            | Boolean        | -     |
+| children      | 组件树                                                                                                                                                                                                    | ReactElement   | -     |
 
 <!-- api-extra-start -->
 

--- a/src/config-provider/config.jsx
+++ b/src/config-provider/config.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 import { obj, log } from '../util';
 import getContextProps from './get-context-props';
+import ErrorBoundary from './error-boundary';
 
 const { shallowEqual } = obj;
 
@@ -89,6 +90,10 @@ export function config(Component, options = {}) {
             locale: PropTypes.object,
             pure: PropTypes.bool,
             rtl: PropTypes.bool,
+            errorBoundary: PropTypes.oneOfType([
+                PropTypes.bool,
+                PropTypes.object,
+            ]),
         };
         static contextTypes = {
             ...(Component.contextTypes || {}),
@@ -97,6 +102,10 @@ export function config(Component, options = {}) {
             nextPure: PropTypes.bool,
             nextRtl: PropTypes.bool,
             nextWarning: PropTypes.bool,
+            nextErrorBoundary: PropTypes.oneOfType([
+                PropTypes.bool,
+                PropTypes.object,
+            ]),
         };
 
         constructor(props, context) {
@@ -132,18 +141,26 @@ export function config(Component, options = {}) {
         }
 
         render() {
-            const { prefix, locale, pure, rtl, ...others } = this.props;
+            const {
+                prefix,
+                locale,
+                pure,
+                rtl,
+                errorBoundary,
+                ...others
+            } = this.props;
             const {
                 nextPrefix,
                 nextLocale = {},
                 nextPure,
                 nextRtl,
+                nextErrorBoundary = {},
             } = this.context;
 
             const displayName =
                 options.componentName || getDisplayName(Component);
             const contextProps = getContextProps(
-                { prefix, locale, pure, rtl },
+                { prefix, locale, pure, rtl, errorBoundary },
                 {
                     nextPrefix,
                     nextLocale: { ...currentGlobalLocale, ...nextLocale },
@@ -154,10 +171,12 @@ export function config(Component, options = {}) {
                             : currentGlobalRtl === true
                             ? true
                             : undefined,
+                    nextErrorBoundary,
                 },
                 displayName
             );
 
+            // errorBoundary is only for <ErrorBoundary>
             const newContextProps = ['prefix', 'locale', 'pure', 'rtl'].reduce(
                 (ret, name) => {
                     if (typeof contextProps[name] !== 'undefined') {
@@ -172,12 +191,20 @@ export function config(Component, options = {}) {
                 ? options.transform(others, this._deprecated)
                 : others;
 
-            return (
+            const content = (
                 <Component
                     {...newOthers}
                     {...newContextProps}
                     ref={this._getInstance}
                 />
+            );
+
+            const { open, ...othersBoundary } = contextProps.errorBoundary;
+
+            return open ? (
+                <ErrorBoundary {...othersBoundary}>{content}</ErrorBoundary>
+            ) : (
+                content
             );
         }
     }

--- a/src/config-provider/error-boundary.jsx
+++ b/src/config-provider/error-boundary.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+DefaultUI.propTypes = {
+    error: PropTypes.object,
+    errorInfo: PropTypes.object,
+};
+
+function DefaultUI() {
+    return '';
+}
+
+export default class ErrorBoundary extends React.Component {
+    static propTypes = {
+        children: PropTypes.element,
+        /**
+         * 捕获错误后的自定义处理, 比如埋点上传
+         * @param {Object} error 错误
+         * @param {Object} errorInfo 错误详细信息
+         */
+        afterCatch: PropTypes.func,
+        /**
+         * 捕获错误后的展现 自定义组件
+         * @param {Object} error 错误
+         * @param {Object} errorInfo 错误详细信息
+         * @returns {Element} 捕获错误后的处理
+         */
+        fallbackUI: PropTypes.func,
+    };
+
+    constructor(props) {
+        super(props);
+        this.state = { error: null, errorInfo: null };
+    }
+
+    componentDidCatch(error, errorInfo) {
+        this.setState({
+            error: error,
+            errorInfo: errorInfo,
+        });
+
+        const { afterCatch } = this.props;
+
+        if ('afterCatch' in this.props && typeof afterCatch === 'function') {
+            this.props.afterCatch(error, errorInfo);
+        }
+    }
+
+    render() {
+        const { fallbackUI: FallbackUI = DefaultUI } = this.props;
+
+        if (this.state.errorInfo) {
+            return (
+                <FallbackUI
+                    error={this.state.error}
+                    errorInfo={this.state.errorInfo}
+                />
+            );
+        }
+        // Normally, just render children
+        return this.props.children;
+    }
+}

--- a/src/config-provider/get-context-props.jsx
+++ b/src/config-provider/get-context-props.jsx
@@ -1,6 +1,13 @@
 export default function getContextProps(props, context, displayName) {
-    const { prefix, locale, pure, rtl } = props;
-    const { nextPrefix, nextLocale, nextPure, nextWarning, nextRtl } = context;
+    const { prefix, locale, pure, rtl, errorBoundary } = props;
+    const {
+        nextPrefix,
+        nextLocale,
+        nextPure,
+        nextWarning,
+        nextRtl,
+        nextErrorBoundary,
+    } = context;
 
     const newPrefix = prefix || nextPrefix;
 
@@ -21,11 +28,28 @@ export default function getContextProps(props, context, displayName) {
     const newPure = typeof pure === 'boolean' ? pure : nextPure;
     const newRtl = typeof rtl === 'boolean' ? rtl : nextRtl;
 
+    // ProtoType of [nextE|e]rrorBoundary can be one of [boolean, object]
+    // but typeof newErrorBoundary === 'object'
+    // newErrorBoundary should always have the key 'open', which indicates ErrorBoundary on or off
+    const newErrorBoundary = {
+        ...(typeof nextErrorBoundary === 'boolean'
+            ? { open: nextErrorBoundary }
+            : nextErrorBoundary),
+        ...(typeof errorBoundary === 'boolean'
+            ? { open: errorBoundary }
+            : errorBoundary),
+    };
+
+    if (!('open' in newErrorBoundary)) {
+        newErrorBoundary.open = false;
+    }
+
     return {
         prefix: newPrefix,
         locale: newLocale,
         pure: newPure,
         rtl: newRtl,
         warning: nextWarning,
+        errorBoundary: newErrorBoundary,
     };
 }

--- a/src/config-provider/index.jsx
+++ b/src/config-provider/index.jsx
@@ -12,6 +12,7 @@ import {
     getDirection,
 } from './config';
 import Consumer from './consumer';
+import ErrorBoundary from './error-boundary';
 import Cache from './cache';
 
 const childContextCache = new Cache();
@@ -30,6 +31,14 @@ class ConfigProvider extends Component {
          * 国际化文案对象，属性为组件的 displayName
          */
         locale: PropTypes.object,
+        /**
+         * 是否开启错误捕捉 errorBoundary
+         * 如需自定义参数，请传入对象 对象接受参数列表如下：
+         *
+         * fallbackUI `Function(error?: {}, errorInfo?: {}) => Element` 捕获错误后的展示
+         * afterCatch `Function(error?: {}, errorInfo?: {})` 捕获错误后的行为, 比如埋点上传
+         */
+        errorBoundary: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
         /**
          * 是否开启 Pure Render 模式，会提高性能，但是也会带来副作用
          */
@@ -50,6 +59,7 @@ class ConfigProvider extends Component {
 
     static defaultProps = {
         warning: true,
+        errorBoundary: false,
     };
 
     static childContextTypes = {
@@ -58,6 +68,10 @@ class ConfigProvider extends Component {
         nextPure: PropTypes.bool,
         nextRtl: PropTypes.bool,
         nextWarning: PropTypes.bool,
+        nextErrorBoundary: PropTypes.oneOfType([
+            PropTypes.bool,
+            PropTypes.object,
+        ]),
     };
 
     /**
@@ -92,10 +106,17 @@ class ConfigProvider extends Component {
     static getLocale = getLocale;
     static getDirection = getDirection;
     static Consumer = Consumer;
+    static ErrorBoundary = ErrorBoundary;
 
     static getContext = () => {
-        const { nextPrefix, nextLocale, nextPure, nextRtl, nextWarning } =
-            childContextCache.root() || {};
+        const {
+            nextPrefix,
+            nextLocale,
+            nextPure,
+            nextRtl,
+            nextWarning,
+            nextErrorBoundary,
+        } = childContextCache.root() || {};
 
         return {
             prefix: nextPrefix,
@@ -103,6 +124,7 @@ class ConfigProvider extends Component {
             pure: nextPure,
             rtl: nextRtl,
             warning: nextWarning,
+            errorBoundary: nextErrorBoundary,
         };
     };
 
@@ -119,7 +141,14 @@ class ConfigProvider extends Component {
     }
 
     getChildContext() {
-        const { prefix, locale, pure, warning, rtl } = this.props;
+        const {
+            prefix,
+            locale,
+            pure,
+            warning,
+            rtl,
+            errorBoundary,
+        } = this.props;
 
         return {
             nextPrefix: prefix,
@@ -127,6 +156,7 @@ class ConfigProvider extends Component {
             nextPure: pure,
             nextRtl: rtl,
             nextWarning: warning,
+            nextErrorBoundary: errorBoundary,
         };
     }
 

--- a/test/config-provider/index-spec.js
+++ b/test/config-provider/index-spec.js
@@ -6,6 +6,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import moment from 'moment';
 import assert from 'power-assert';
 import Select from '../../src/select';
+import Button from '../../src/button';
 import enUS from '../../src/locale/en-us';
 import zhCN from '../../src/locale/zh-cn';
 import ConfigProvider from '../../src/config-provider';
@@ -15,7 +16,7 @@ import ConfigProvider from '../../src/config-provider';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const { config, getContextProps } = ConfigProvider;
+const { config, getContextProps, ErrorBoundary } = ConfigProvider;
 
 class Output extends Component {
     static propTypes = {
@@ -406,5 +407,43 @@ describe('ConfigProvider.Consumer', () => {
         assert.equal(output.prop('locale'), contextState.locale);
         assert(output.prop('pure') === contextState.pure);
         assert(output.prop('warning') === contextState.warning);
+    });
+});
+
+describe('ConfigProvider.ErrorBoundary', () => {
+    let wrapper;
+
+    afterEach(() => {
+        if (wrapper) {
+            wrapper.unmount();
+            wrapper = null;
+        }
+    });
+
+    it('should catch errors with componentDidCatch', () => {
+        const Something = () => null;
+
+        wrapper = mount(
+            <ErrorBoundary>
+                <Something />
+            </ErrorBoundary>
+        );
+        const error = new Error('test');
+
+        wrapper.find(Something).simulateError(error);
+    });
+
+    it('should catch errors with componentDidCatch as to basic component', () => {
+        const Something = () => null;
+        wrapper = mount(
+            <ConfigProvider errorBoundary>
+                <Button>
+                    <Something />
+                </Button>
+            </ConfigProvider>
+        );
+        const error = new Error('test');
+
+        wrapper.find(Something).simulateError(error);
     });
 });


### PR DESCRIPTION
Wrap with <ErrorBoundary> causes tests failure.

 e.g. shallow(<Checkbox></Checkbox>).dive() is not enough, should use shallow(<Checkbox></Checkbox>).dive().dive()

I'm thinking about whether to do the Wrap or not.