### PR TITLE
chore(*): make sure rendering done before a11y test

### DIFF
--- a/test/util/a11y/validate.js
+++ b/test/util/a11y/validate.js
@@ -110,8 +110,10 @@ export const mountReact = async function(node, id = A11Y_ROOT_ID) {
  */
 // TODO: resolve issue where failing tests do not pass wrapper and so cannot be cleaned up correctly
 export const testReact = async function(node, options = {}) {
-    const wrapper = mountReact(node, A11Y_ROOT_ID);
-    await test(`#${A11Y_ROOT_ID}`, options);
+    const wrapper = await mountReact(node, A11Y_ROOT_ID);
+    setTimeout(async () => {
+        await test(`#${A11Y_ROOT_ID}`, options);
+    }, 100);
     return wrapper;
 };
 


### PR DESCRIPTION
I added some time delay before a11y test, it passed in my fork https://travis-ci.com/youluna/next/builds/103822265