### PR TITLE
fix(Tag): close button not showing in select when text too long

### DIFF
--- a/src/tag/main.scss
+++ b/src/tag/main.scss
@@ -121,6 +121,18 @@
     &tag-closable {
         position: relative;
 
+        &.#{$css-prefix}tag-large > .#{$css-prefix}tag-body {
+            max-width: calc(100% - #{$tag-size-l-height});
+        }
+
+        &.#{$css-prefix}tag-medium > .#{$css-prefix}tag-body {
+            max-width: calc(100% - #{$tag-size-m-height});
+        }
+
+        &.#{$css-prefix}tag-small > .#{$css-prefix}tag-body {
+            max-width: calc(100% - #{$tag-size-s-height});
+        }
+
         > .#{$css-prefix}tag-close-btn {
             display: inline-block;
             vertical-align: middle;

--- a/src/tag/scss/mixin.scss
+++ b/src/tag/scss/mixin.scss
@@ -20,7 +20,7 @@
     line-height: $height - $borderWidth * 2;
     font-size: 0;
 
-    $_marginLeft: $height / 4 - 1px;
+    $_marginLeft: $iconSize;
 
     > .#{$css-prefix}tag-body {
         font-size: $fontSize;


### PR DESCRIPTION
- set max width for the body to make sure the close button appears
- increase the icon left margin to not trigger the ellipses unnecessarily