### PR TITLE
fix(Tab): slide related issues

### DIFF
--- a/docs/tab/demo/excess-mode.md
+++ b/docs/tab/demo/excess-mode.md
@@ -43,7 +43,7 @@ function onClick(key) {
 
 ReactDOM.render(<div className="fusion-demo" style={{ maxWidth: '520px' }}>
     <div className="demo-item-title">Dropdown mode</div>
-    <Tab excessMode="dropdown">
+    <Tab excessMode="dropdown" popupProps={{style: {maxHeight: 400, overflowY: 'scroll'}}}>
         {
             tabs.map(item => <Tab.Item key={item.key} title={item.tab} onClick={onClick}>{item.tab} content, content, content</Tab.Item>)
         }

--- a/docs/tab/demo/excess-mode.md
+++ b/docs/tab/demo/excess-mode.md
@@ -43,7 +43,7 @@ function onClick(key) {
 
 ReactDOM.render(<div className="fusion-demo" style={{ maxWidth: '520px' }}>
     <div className="demo-item-title">Dropdown mode</div>
-    <Tab excessMode="dropdown" popupProps={{style: {maxHeight: 400, overflowY: 'scroll'}}}>
+    <Tab excessMode="dropdown">
         {
             tabs.map(item => <Tab.Item key={item.key} title={item.tab} onClick={onClick}>{item.tab} content, content, content</Tab.Item>)
         }

--- a/docs/tab/demo/extra.md
+++ b/docs/tab/demo/extra.md
@@ -2,14 +2,14 @@
 
 - order: 11
 
-通过 `extra` 属性添加附加内容，请确保只在有限选项卡的情况下才使用附加内容。
+通过 `extra` 属性添加附加内容，请确保只在有限选项卡的情况下才使用附加内容, 该功能在选项卡溢出时会和溢出导航的按钮冲突。
 
 :::lang=en-us
 # Extra
 
 - order: 11
 
-Pass your custom contents to `extra`.
+Pass your custom contents to `extra`, please consider using this when the tab-items are limited, since it is not designed to be used in combination with excess-mode.
 
 :::
 

--- a/docs/tab/index.en-us.md
+++ b/docs/tab/index.en-us.md
@@ -35,7 +35,7 @@ Disable animation with `animation={false}`
 | navClassName        | Custom className of nav | String        | -        |
 | contentStyle        | Custom style of content | Object        | -        |
 | contentClassName    | Custom className of content | String        | -        |
-| extra               | Extra content of tab | ReactNode     | -        |
+| extra               | Extra content of tab, ensure the item won't excess when using this | ReactNode     | -        |
 | onClick             | Callback when click tab | Function      | () => {} |
 | onChange            | Callback when active tab changes<br><br>**signature**:<br>Function(key: String/Number)) => void<br>**parameter**:<br>_key_: {String/Number)} theActiveKey   | Function      | () => {} |
 | onClose             | Callback when close the tab<br><br>**signature**:<br>Function(key: String/Number)) => void<br>**parameter**:<br>_key_: {String/Number)} theClosedKey  | Function      | () => {} |

--- a/src/tab/main.scss
+++ b/src/tab/main.scss
@@ -13,6 +13,10 @@
 
     &-bar {
         outline: none;
+        &-popup {
+            overflow-y: auto;
+            max-height: 480px;
+        }
     }
 
     &-nav-container {

--- a/src/tab/rtl.scss
+++ b/src/tab/rtl.scss
@@ -1,7 +1,7 @@
 @import "../core/index-noreset.scss";
 @import "scss/variable";
 
-#{$tab-prefix}[dir="rtl"] {
+#{$tab-prefix}[dir='rtl'] {
     &.#{$css-prefix}medium {
         & #{$tab-prefix}-nav-container-scrolling {
             padding-left: $tab-nav-scroll-padding-right-m;
@@ -54,6 +54,16 @@
     #{$tab-prefix}-btn-down {
         left: $tab-nav-arrow-down-positon-right;
         right: auto;
+    }
+}
+#{$tab-prefix}-text[dir='rtl'] > #{$tab-prefix}-bar {
+    #{$tab-prefix}-tab {
+        &:not(:last-child):after {
+            content: ' ';
+            position: absolute;
+            left: 0;
+            right: auto;
+        }
     }
 }
 

--- a/src/tab/tabs/nav.jsx
+++ b/src/tab/tabs/nav.jsx
@@ -461,6 +461,7 @@ class Nav extends React.Component {
                 triggerType={triggerType}
                 trigger={trigger}
                 container={target => target.parentNode}
+                className={`${prefix}tabs-bar-popup`}
                 {...popupProps}
             >
                 <Menu


### PR DESCRIPTION
CAUSION: 重大改动
现在prev和next的disable和enable的状态将和navbar的offset一样只是组件的样式，不再是组件的内部状态，不触发重新渲染。同时组件update时开启auto scroll to active tab的功能，即自动将”半进入“可见区域的tab自动滚动到可见区内，这个滚动只会带来prev和next的样式变化，所以可以放心开启。从根本上解决了：
#429 #226 以及 http://fusion-image.oss-cn-beijing.aliyuncs.com/test/bug.mov