### PR TITLE
fix(Nav): remove focus style which equals to hover

### DIFF
--- a/docs/nav/theme/index.jsx
+++ b/docs/nav/theme/index.jsx
@@ -55,7 +55,7 @@ class FuncDemo extends React.Component {
         return (
             <Nav defaultOpenAll type={type} direction={direction} activeDirection={activeDirection} iconOnly={iconOnly} defaultSelectedKeys={selectedKeys}>
                 {hasGroup ? <Group label={i18n.group}>{items}</Group> : items}
-                <SubNav style={itemStyle} key="5" icon={hasIcons && 'account'} label={`${i18n.item}5`}>
+                <SubNav key="5" icon={hasIcons && 'account'} label={`${i18n.item}5`}>
                     {subItems}
                 </SubNav>
             </Nav>

--- a/src/menu/main.scss
+++ b/src/menu/main.scss
@@ -98,7 +98,6 @@
         &:not(.#{$css-prefix}disabled).#{$css-prefix}selected.#{$css-prefix}focused:hover,
         &:not(.#{$css-prefix}disabled).#{$css-prefix}selected:focus:hover,
         &:not(.#{$css-prefix}disabled).#{$css-prefix}focused,
-        &:not(.#{$css-prefix}disabled):focus,
         &:not(.#{$css-prefix}disabled).#{$css-prefix}selected.#{$css-prefix}focused,
         &:not(.#{$css-prefix}disabled).#{$css-prefix}selected:focus {
             @include menu-item-state(

--- a/src/nav/main.scss
+++ b/src/nav/main.scss
@@ -46,7 +46,6 @@ $nav-icononly-width: $s-15;
 
         &,
         &:hover,
-        &:focus,
         &.#{$css-prefix}focused,
         &.#{$css-prefix}selected,
         &.#{$css-prefix}opened {

--- a/src/nav/scss/mixin.scss
+++ b/src/nav/scss/mixin.scss
@@ -111,7 +111,6 @@
         color: $textColor;
 
         &.#{$css-prefix}focused,
-        &:focus,
         &:hover {
             background-color: $hoverBgColor;
             color: $hoverColor;
@@ -160,7 +159,6 @@
         font-weight: $textWeight;
 
         &.#{$css-prefix}focused,
-        &:focus,
         &:hover {
             background-color: $hoverBgColor;
             color: $hoverColor;


### PR DESCRIPTION
- 移除focus样式。当前focus样式同hover样式完全一样，会给正常使用的用户带来困扰。
- 修复menu配置demo的bug