### PR TITLE
fix(Menu): Resolve expanding and selecting in uncontrolled mode

### DIFF
--- a/src/menu/view/menu.jsx
+++ b/src/menu/view/menu.jsx
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import { func, obj, KEYCODE } from '../../util';
 
 const { bindCtx } = func;
-const { pickOthers } = obj;
+const { pickOthers, isNil } = obj;
 const noop = () => {};
 
 /**
@@ -214,12 +214,13 @@ export default class Menu extends Component {
         if (focusable) {
             this.tabbableKey = this.getFirstAvaliablelChildKey('0');
         }
+
         this.state = {
             openKeys: this.getInitOpenKeys(props),
             selectedKeys: this.normalizeToArray(
                 selectedKeys || defaultSelectedKeys
             ),
-            focusedKey: this.props.focusedKey
+            focusedKey: !isNil(this.props.focusedKey)
                 ? focusedKey
                 : focusable && autoFocus
                 ? this.tabbableKey
@@ -479,7 +480,7 @@ export default class Menu extends Component {
         }
 
         if (newOpenKeys) {
-            if (!this.props.openKeys) {
+            if (isNil(this.props.openKeys)) {
                 this.setState({
                     openKeys: newOpenKeys,
                 });
@@ -538,7 +539,7 @@ export default class Menu extends Component {
         }
 
         if (newSelectedKeys) {
-            if (!this.props.selectedKeys) {
+            if (isNil(this.props.selectedKeys)) {
                 this.setState({
                     selectedKeys: newSelectedKeys,
                 });
@@ -555,7 +556,7 @@ export default class Menu extends Component {
 
     handleItemClick(key, item, e) {
         if (this.props.focusable) {
-            if (!this.props.focusedKey) {
+            if (isNil(this.props.focusedKey)) {
                 this.setState({
                     focusedKey: key,
                 });
@@ -569,7 +570,7 @@ export default class Menu extends Component {
                 item.props.parentMode === 'popup' &&
                 this.state.openKeys.length
             ) {
-                if (!this.props.openKeys) {
+                if (isNil(this.props.openKeys)) {
                     this.setState({
                         openKeys: [],
                     });
@@ -722,7 +723,7 @@ export default class Menu extends Component {
         }
 
         if (focusedKey !== this.state.focusedKey) {
-            if (!this.props.focusedKey) {
+            if (isNil(this.props.focusedKey)) {
                 this.setState({
                     focusedKey,
                 });

--- a/src/menu/view/menu.jsx
+++ b/src/menu/view/menu.jsx
@@ -219,12 +219,11 @@ export default class Menu extends Component {
             selectedKeys: this.normalizeToArray(
                 selectedKeys || defaultSelectedKeys
             ),
-            focusedKey:
-                'focusedKey' in this.props
-                    ? focusedKey
-                    : focusable && autoFocus
-                    ? this.tabbableKey
-                    : null,
+            focusedKey: this.props.focusedKey
+                ? focusedKey
+                : focusable && autoFocus
+                ? this.tabbableKey
+                : null,
         };
 
         bindCtx(this, [
@@ -480,7 +479,7 @@ export default class Menu extends Component {
         }
 
         if (newOpenKeys) {
-            if (!('openKeys' in this.props)) {
+            if (!this.props.openKeys) {
                 this.setState({
                     openKeys: newOpenKeys,
                 });
@@ -539,7 +538,7 @@ export default class Menu extends Component {
         }
 
         if (newSelectedKeys) {
-            if (!('selectedKeys' in this.props)) {
+            if (!this.props.selectedKeys) {
                 this.setState({
                     selectedKeys: newSelectedKeys,
                 });
@@ -556,7 +555,7 @@ export default class Menu extends Component {
 
     handleItemClick(key, item, e) {
         if (this.props.focusable) {
-            if (!('focusedKey' in this.props)) {
+            if (!this.props.focusedKey) {
                 this.setState({
                     focusedKey: key,
                 });
@@ -570,7 +569,7 @@ export default class Menu extends Component {
                 item.props.parentMode === 'popup' &&
                 this.state.openKeys.length
             ) {
-                if (!('openKeys' in this.props)) {
+                if (!this.props.openKeys) {
                     this.setState({
                         openKeys: [],
                     });
@@ -723,7 +722,7 @@ export default class Menu extends Component {
         }
 
         if (focusedKey !== this.state.focusedKey) {
-            if (!('focusedKey' in this.props)) {
+            if (!this.props.focusedKey) {
                 this.setState({
                     focusedKey,
                 });

--- a/src/util/object.js
+++ b/src/util/object.js
@@ -221,3 +221,14 @@ export function pickAttrsWith(holdProps, prefix) {
 
     return others;
 }
+
+/**
+ * Checks if value is `null` or `undefined`.
+ * @param {*} value
+ * @return {Boolean}
+ */
+export function isNil(value) {
+    // It will returns `true` only if `null` or `undefined` compare with `null`
+    // with loose equaliy
+    return value == null; // eslint-disable-line eqeqeq
+}

--- a/test/util/object-spec.js
+++ b/test/util/object-spec.js
@@ -155,4 +155,48 @@ describe('src/object.js', function() {
             assert('data-cool' in res);
         });
     });
+
+    describe('#isNil', function () {
+        it(
+            'should returns `true` if passing `null` or `undefined`',
+            function () {
+                const values = [null, undefined];
+                values.forEach(function (value) {
+                    assert(object.isNil(value) === true);
+                });
+            }
+        );
+
+        it(
+            'should returns `false` if passing a falsy value ' +
+            'except `null` or `undefined`',
+            function () {
+                const values = ['', 0, false, NaN];
+                values.forEach(function (value) {
+                    assert(object.isNil(value) === false);
+                });
+            }
+        );
+
+        it(
+            'should returns `false` if passing a truthy value',
+            function () {
+                const values = [
+                    'string',
+                    '0',
+                    'false',
+                    1,
+                    -1,
+                    Infinity,
+                    [],
+                    {},
+                    function(){},
+                    /.*/
+                ];
+                values.forEach(function (value) {
+                    assert(object.isNil(value) === false);
+                });
+            }
+        );
+    });
 });


### PR DESCRIPTION
A `in` expression was used in previous conditional branches, that
expected to determine whether a specific props has been declared
at the component.

e.g.:

```javascript
class MyComponent extends Component {
  componentDidMount() {
    // print `foo` if `this.props.foo` is not declared
    if (!('foo' in this.props)) {
      console.log('bar')
    }
  }

  render() {
    return (
      <div>{this.props.foo}</div>
    )
  }
}
```

In most cases, there has no problems if the prop `foo` is not
declared:

```javascript
// `foo` is not declared,
// and it will print `bar` when component did mount.
<MyComponent />
```

But it still has problems in some specific edge cases:

```javascript
// `foo` is declared as an undefined value,
// and `foo` is in the component's props.
// `bar` will not be printed.
<MyComponent foo={undefined} />

// There has another use case with the same problem and subtle crack
// when you wrap another component with it.
const AnotherComponent = ({ anotherFoo }) => (
  <MyComponent foo={anotherFoo} />
)

// `bar` will not be printed.
<AnotherComponent />
```