### PR TITLE
fix(Tab): should not listen to extra keyboard events

### DIFF
--- a/src/tab/tabs/nav.jsx
+++ b/src/tab/tabs/nav.jsx
@@ -604,7 +604,11 @@ class Nav extends React.Component {
         const tabList = this.renderTabList(this.props);
 
         const container = (
-            <div className={containerCls} key="nav-container">
+            <div
+                className={containerCls}
+                onKeyDown={onKeyDown}
+                key="nav-container"
+            >
                 <div
                     className={`${prefix}tabs-nav-wrap`}
                     ref={this.wrapperRefHandler}
@@ -670,7 +674,6 @@ class Nav extends React.Component {
             <div
                 className={navbarCls}
                 style={style}
-                onKeyDown={onKeyDown}
                 ref={this.navbarRefHandler}
             >
                 {navChildren}


### PR DESCRIPTION
Remove extra from the listened area of keydown event.
Closing #643 