### PR TITLE
chore(Upload): correct TypeScript Upload Dragger props

### DIFF
--- a/types/upload/index.d.ts
+++ b/types/upload/index.d.ts
@@ -186,16 +186,9 @@ export interface CardProps extends HTMLAttributesWeak {
     onCancel?: () => void;
 }
 
-export class Card extends React.Component<CardProps, any> { }
+export class Card extends React.Component<CardProps, any> {}
 
-export interface DraggerProps extends React.HTMLAttributes<HTMLElement> {
-    /**
-     * 样式前缀
-     */
-    prefix?: string;
-}
-
-export class Dragger extends React.Component<DraggerProps, any> { }
+export class Dragger extends React.Component<UploadProps, any> {}
 
 interface HTMLAttributesWeak extends React.HTMLAttributes<HTMLElement> {
     onSelect?: any;
@@ -243,7 +236,7 @@ export interface SelecterProps extends HTMLAttributesWeak {
     onDrop?: () => void;
 }
 
-export class Selecter extends React.Component<SelecterProps, any> { }
+export class Selecter extends React.Component<SelecterProps, any> {}
 interface HTMLAttributesWeak extends React.HTMLAttributes<HTMLElement> {
     onError?: any;
     onSelect?: any;


### PR DESCRIPTION
Closes https://github.com/alibaba-fusion/next/issues/936

DraggerProps 直接继承 UploadProps 即可。