### PR TITLE
fix(Dialog): quick-calling support set prefix to dialog

### DIFF
--- a/src/dialog/show.jsx
+++ b/src/dialog/show.jsx
@@ -174,6 +174,7 @@ class Modal extends Component {
 
         return (
             <Dialog
+                prefix={prefix}
                 role="alertdialog"
                 {...others}
                 visible={visible}

--- a/test/dialog/index-spec.js
+++ b/test/dialog/index-spec.js
@@ -557,6 +557,20 @@ describe('inner', () => {
         assert(!document.querySelector('.far-overlay-wrapper'));
     });
 
+    it('quick-calling should should support set prefix for dialog', () => {
+        const { hide } = Dialog.show({
+            prefix: 'test-',
+            title: 'Title',
+            content: 'Content',
+        });
+
+        assert(
+            hasClass(document.querySelector('.test-dialog'), 'test-closeable')
+        );
+
+        hide();
+    });
+
     it('should throw error (async)', () => {
         const { hide } = Dialog.show({
             title: 'Title',


### PR DESCRIPTION
修改后， 快捷调用时，设置 prefix ，会同时对 dialog 生效。 