### PR TITLE
feat(Rating): add preview state

### DIFF
--- a/src/rating/index.jsx
+++ b/src/rating/index.jsx
@@ -10,6 +10,9 @@ export default ConfigProvider.config(Rating, {
             props = { showGrade: type === 'grade', ...others };
         }
 
+        const { disabled, readOnly } = props;
+        props.disabled = disabled || readOnly;
+
         return props;
     },
 });


### PR DESCRIPTION
- 增加state属性，可选参数有 preview normal
- 增加renderPreview(value: number, props: {})函数，用于用户自定义预览态
- 增加readOnly属性，默认情况下Rating的预览态就是readOnly态