### PR TITLE
fix(Notification): title and content are not both required

### DIFF
--- a/src/notification/index.jsx
+++ b/src/notification/index.jsx
@@ -188,7 +188,7 @@ let mounting = false;
 let waitOpens = [];
 
 function open(options = {}) {
-    if (!options.title || !options.content) return;
+    if (!options.title && !options.content) return;
 
     const duration =
         !options.duration && options.duration !== 0


### PR DESCRIPTION
现在Notification的title和content都是必填，否则出不来，应该是任选其一展示就可以