### PR TITLE
Fixed(Notification): type define error

### DIFF
--- a/types/notification/index.d.ts
+++ b/types/notification/index.d.ts
@@ -23,13 +23,13 @@ export interface NotificationOptions {
 }
 
 export default class Notification {
-    config: (config: NotificationConfig) => NotificationConfig;
-    open: (options: NotificationOptions) => string;
-    close: (key: string) => void;
-    destroy: () => void;
-    success: (options: NotificationOptions) => string;
-    error: (options: NotificationOptions) => string;
-    warning: (options: NotificationOptions) => string;
-    notice: (options: NotificationOptions) => string;
-    help: (options: NotificationOptions) => string;
+    static config: (config: NotificationConfig) => NotificationConfig;
+    static open: (options: NotificationOptions) => string;
+    static close: (key: string) => void;
+    static destroy: () => void;
+    static success: (options: NotificationOptions) => string;
+    static error: (options: NotificationOptions) => string;
+    static warning: (options: NotificationOptions) => string;
+    static notice: (options: NotificationOptions) => string;
+    static help: (options: NotificationOptions) => string;
 }


### PR DESCRIPTION
Fixed type error related to alibaba-fusion#1322

Notification.success(config)
Notification.error(config)
Notification.warning(config)
Notification.notice(config)
Notification.help(config)
Notification.open(config)
Notification.close(key: String)
Notification.destroy()