### PR TITLE
fix(Upload): bugs of IE

### DIFF
--- a/src/upload/runtime/request.jsx
+++ b/src/upload/runtime/request.jsx
@@ -73,6 +73,11 @@ export default function upload(option) {
         option.onSuccess(getBody(xhr), xhr);
     };
 
+    option.method = option.method || 'POST';
+    xhr.open(option.method, option.action, true);
+
+    // In Internet Explorer, the timeout property may be set only after calling the open() method and before calling the send() method.
+    // see https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout
     const { timeout } = option;
 
     if (typeof timeout === 'number' && timeout > 0) {
@@ -82,9 +87,6 @@ export default function upload(option) {
             option.onError(getError(option, xhr, msg), getBody(xhr));
         };
     }
-
-    option.method = option.method || 'POST';
-    xhr.open(option.method, option.action, true);
 
     // Has to be after `.open()`. See https://github.com/enyo/dropzone/issues/179
     if (option.withCredentials && 'withCredentials' in xhr) {

--- a/src/upload/runtime/selecter.jsx
+++ b/src/upload/runtime/selecter.jsx
@@ -81,8 +81,9 @@ export default class Selecter extends React.Component {
         if (!el) {
             return;
         }
-        el.click();
+        // NOTE: 在 IE 下，el.value = '' 在 el.click() 之后，会触发 input[type=file] 两次 onChange
         el.value = '';
+        el.click();
     };
 
     /**


### PR DESCRIPTION
修复 Upload 组件在 IE 浏览器（IE11）下的兼容性问题：
- 在 IE 浏览器下，`timeout` 属性必须设置在  `xhr.open` 之后 `xhr.send()` 之前
- 手动触发 `input[type=file]` 的 `click` 事件之后又设置 `el.value = ""`，会触发 `input[type=file]` 两次 `onChange` 事件