### PR TITLE
fix(Cascader): expand former value after search

### DIFF
--- a/src/cascader/cascader.jsx
+++ b/src/cascader/cascader.jsx
@@ -208,11 +208,15 @@ export default class Cascader extends Component {
                     state.value
                 );
             }
-            if (
-                !this.state.expandedValue.length &&
-                !('expandedValue' in nextProps)
-            ) {
-                state.expandedValue = this.getExpandedValue(state.value[0]);
+            if (!('expandedValue' in nextProps)) {
+                let expandedValue = this.getExpandedValue(state.value[0]);
+                if (
+                    this.state.expandedValue.length &&
+                    expandedValue.length &&
+                    expandedValue[0] !== this.state.expandedValue[0]
+                ) {
+                    state.expandedValue = expandedValue;
+                }
             }
         }
         if ('expandedValue' in nextProps) {


### PR DESCRIPTION
CascaderSelect在搜索选定之后，再下拉不能展开正确的列表，分析之后是cascader组件在检测了状态存在展开的值就不进行更新，添加这种情况对state进行更新的代码