### PR TITLE
fix(Table): disorder with mouse

### DIFF
--- a/src/table/fixed.jsx
+++ b/src/table/fixed.jsx
@@ -125,7 +125,7 @@ export default function fixed(BaseComponent) {
                 if (+scrollBarSize) {
                     style.marginBottom = -scrollBarSize;
                     if (hasHozScroll) {
-                        style.paddingBottom = 0;
+                        style.paddingBottom = scrollBarSize;
                     } else {
                         style.paddingBottom = scrollBarSize;
                         style[marginName] = 0;

--- a/src/table/lock.jsx
+++ b/src/table/lock.jsx
@@ -447,7 +447,7 @@ export default function lock(BaseComponent) {
 
                 if (+scrollBarSize) {
                     style.marginBottom = -scrollBarSize;
-                    style.paddingBottom = 0;
+                    style.paddingBottom = scrollBarSize;
                 } else {
                     style.marginBottom = -20;
                     style.paddingBottom = 20;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10049465/71891269-36505d00-3181-11ea-89aa-14d0f0e8a498.png)
修复了  在插着鼠标的时候 fixedHeader  lock 模式下，table header 高度不一致问题