### PR TITLE
docs(Input): can not see normal background

### DIFF
--- a/docs/input/theme/index.jsx
+++ b/docs/input/theme/index.jsx
@@ -54,10 +54,10 @@ function render(i18n) {
         <Demo title="Textfield" block>
             <DemoHead cols={['L', 'M', 'S']}/>
 
-            <DemoGroup label="Normal">
-                <Input placeholder={i18n.large} size="large"/>
-                <Input placeholder={i18n.medium}/>
-                <Input placeholder={i18n.small} size="small"/>
+            <DemoGroup label="Normal" id="test">
+                <Input placeholder={i18n.large} size="large" style={{pointerEvents: 'none'}}/>
+                <Input placeholder={i18n.medium} style={{pointerEvents: 'none'}}/>
+                <Input placeholder={i18n.small} size="small" style={{pointerEvents: 'none'}}/>
             </DemoGroup>
             <DemoGroup label="Focused">
                 <Input value={i18n.focus} size="large" className="next-focus"/>


### PR DESCRIPTION
### 问题
配置Input正常状态下的背景色，配置面板总是不出来
![image](https://user-images.githubusercontent.com/10049465/75543494-de392700-5a5c-11ea-8e2c-a7d7c3c6b011.png)

### 原因
如果点到了Input 触发了focus，那么就成了配置focus的面板，所以点击需要点到白色的地方，不能点到输入框上

![image](https://user-images.githubusercontent.com/10049465/75543465-ce214780-5a5c-11ea-8f86-f1de036fd316.png)

### 解决办法
禁用normal状态下的Input点击