### PR TITLE
fix(ConfigProvider): second params is not required in ts

### DIFF
--- a/types/config-provider/index.d.ts
+++ b/types/config-provider/index.d.ts
@@ -58,6 +58,6 @@ export default class ConfigProvider extends React.Component<
     ConfigProviderProps,
     any
 > {
-    static config(Component: any, options: {}): any;
+    static config(Component: any, options?: {}): any;
     static getContextProps(props: {}, displayName: string): {};
 }


### PR DESCRIPTION
config function second params is not required in ts