### PR TITLE
Fix/hippo compat

### DIFF
--- a/src/menu/index.jsx
+++ b/src/menu/index.jsx
@@ -20,6 +20,12 @@ Menu.create = create;
 
 /* istanbul ignore next */
 const transform = (props, deprecated) => {
+    if ('onClick' in props) {
+        deprecated('onClick', 'onItemClick', 'Menu');
+        const { onClick, ...others } = props;
+        props = { onItemClick: onClick, ...others };
+    }
+
     if ('indentSize' in props) {
         deprecated('indentSize', 'inlineIndent', 'Menu');
 

--- a/src/menu/index.jsx
+++ b/src/menu/index.jsx
@@ -22,8 +22,6 @@ Menu.create = create;
 const transform = (props, deprecated) => {
     if ('onClick' in props) {
         deprecated('onClick', 'onItemClick', 'Menu');
-        const { onClick, ...others } = props;
-        props = { onItemClick: onClick, ...others };
     }
 
     if ('indentSize' in props) {

--- a/src/overlay/overlay.jsx
+++ b/src/overlay/overlay.jsx
@@ -50,7 +50,7 @@ const getStyleProperty = (node, name) => {
 };
 
 const modals = [];
-let bodyOverflowY, bodyPaddingRight;
+let bodyOverflow, bodyPaddingRight;
 
 /**
  * Overlay
@@ -514,10 +514,10 @@ export default class Overlay extends Component {
         if (this.props.disableScroll) {
             if (modals.length === 0) {
                 const style = {
-                    overflowY: 'hidden',
+                    overflow: 'hidden',
                 };
                 const body = document.body;
-                bodyOverflowY = body.style.overflowY;
+                bodyOverflow = body.style.overflow;
                 if (hasScroll()) {
                     bodyPaddingRight = body.style.paddingRight;
                     style.paddingRight = `${dom.getStyle(body, 'paddingRight') +
@@ -536,7 +536,7 @@ export default class Overlay extends Component {
             if (index > -1) {
                 if (modals.length === 1) {
                     const style = {
-                        overflowY: bodyOverflowY,
+                        overflow: bodyOverflow,
                     };
                     if (hasScroll()) {
                         style.paddingRight = bodyPaddingRight;
@@ -544,7 +544,7 @@ export default class Overlay extends Component {
 
                     dom.setStyle(document.body, style);
 
-                    bodyOverflowY = undefined;
+                    bodyOverflow = undefined;
                     bodyPaddingRight = undefined;
                 }
 


### PR DESCRIPTION
1. Menu 的 onClick 兼容 0.x
2. Overlay 兼容 Safari 中的禁用滚动，[参考 ](https://stackoverflow.com/questions/52786341/safari-is-not-preventing-the-scrolling-of-body-style-overflow-y-hidden)