### PR TITLE
fix(DatePicker): should not resetTime as default,close #1840

### DIFF
--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -323,16 +323,18 @@ class DatePicker extends Component {
 
     onDateInputBlur = () => {
         const { dateInputStr, value, format } = this.state;
+        const { resetTime } = this.props;
+
         if (dateInputStr) {
             const { disabledDate } = this.props;
-            const parsed = moment(dateInputStr, format, true);
+            let parsed = moment(dateInputStr, format, true);
 
             this.setState({
                 dateInputStr: '',
                 inputing: false,
             });
-
             if (parsed.isValid() && !disabledDate(parsed, 'date')) {
+                parsed = resetTime ? parsed : resetValueTime(parsed, value);
                 this.handleChange(parsed, value);
             }
         }

--- a/test/date-picker/index-spec.js
+++ b/test/date-picker/index-spec.js
@@ -186,6 +186,28 @@ describe('DatePicker', () => {
             assert(ret.format('YYYY-MM-DD HH:mm:ss') === '2017-11-11 11:11:11');
         });
 
+        it('should not resetTime as default', () => {
+            let ret;
+            wrapper = mount(
+                <DatePicker
+                    onChange={val => (ret = val)}
+                    defaultValue="2017-11-11 11:11:11"
+                    showTime
+                    defaultVisible
+                />
+            );
+
+            wrapper
+                .find('.next-date-picker-panel-input input')
+                .at(0)
+                .simulate('change', { target: { value: '2017-11-12' } });
+            wrapper
+                .find('.next-date-picker-panel-input input')
+                .at(0)
+                .simulate('blur');
+            assert(ret === '2017-11-12 11:11:11');
+        });
+
         it('should input null value in picker', () => {
             let ret;
             wrapper = mount(
@@ -1439,7 +1461,7 @@ describe('RangePicker', () => {
             assert(ret[0].format('YYYY-MM-DD') === '2017-08-01');
         });
 
-        it('should slect range with same day', () => {
+        it('should select range with same day', () => {
             let ret;
             wrapper = mount(
                 <RangePicker
@@ -1652,6 +1674,7 @@ describe('RangePicker', () => {
                     onChange={val => (ret = val)}
                 />
             );
+
             wrapper
                 .find('td[title="2017-11-09"] .next-calendar-date')
                 .simulate('click');
@@ -1733,7 +1756,7 @@ describe('RangePicker', () => {
             );
         });
 
-        it('should not resetTime', () => {
+        it('should not resetTime as default', () => {
             let ret;
 
             wrapper = mount(
@@ -1771,6 +1794,20 @@ describe('RangePicker', () => {
             assert(
                 ret[1].format('YYYY-MM-DD HH:mm:ss') === '2017-12-09 11:11:11'
             );
+            // 选择了一个比开始日期更小的结束日期，此时表示用户重新选择了
+            // 结束日期等于开始日期 不修改时间
+            wrapper
+                .find('.next-range-picker-panel-input-end-date input')
+                .simulate('focus');
+            wrapper
+                .find('td[title="2017-11-08"] .next-calendar-date')
+                .simulate('click');
+            assert(
+                ret[0].format('YYYY-MM-DD HH:mm:ss') === '2017-11-08 10:10:10'
+            );
+            assert(
+                ret[1].format('YYYY-MM-DD HH:mm:ss') === '2017-11-08 11:11:11'
+            );
         });
 
         it('should select a endDay less than the previous startDay', () => {
@@ -1804,10 +1841,12 @@ describe('RangePicker', () => {
                 .find('.next-range-picker-panel-input-start-date input')
                 .simulate('focus');
             wrapper
-                .find('td[title="2017-12-30"] .next-calendar-date')
+                .find('td[title="2017-12-25"] .next-calendar-date')
                 .simulate('click');
-            assert(ret[0].format('YYYY-MM-DD') === '2017-12-30');
-            assert(ret[1] === null);
+            assert.deepEqual(ret.map(m => m.format('YYYY-MM-DD')), [
+                '2017-12-25',
+                '2017-12-25',
+            ]);
         });
 
         it('should select endDate firstly', () => {


### PR DESCRIPTION
- 当开始和结束选同一个日期的时候，会导致结束时间被清空，开始时间置0
- 手动修改日期的时候，也会导致时间被置0

![Kapture 2020-05-19 at 16 24 52](https://user-images.githubusercontent.com/8581684/82303331-650ef780-99ed-11ea-929b-b62d700a018b.gif)

修复：
修改日期时，如果起始时间和结束时间是合理的，不会重置时间