### PR TITLE
fix(Box): resolve justify wont work when wrap&spacing setted, close#1855

### DIFF
--- a/src/responsive-grid/create-style.js
+++ b/src/responsive-grid/create-style.js
@@ -152,7 +152,7 @@ const helperProps = [
 const innerProps = [
     'flexDirection',
     'flexWrap',
-    'justifyContent',
+    // 'justifyContent',
     'alignContent',
     'alignItems',
     'display',

--- a/test/box/index-spec.js
+++ b/test/box/index-spec.js
@@ -74,4 +74,19 @@ describe('Box', () => {
 
         assert(wrapper.find('.next-box'));
     });
+
+    it("justify should work when wrap and spacing setted", () => {
+        wrapper = mount(
+            <Box className="test" wrap spacing={20} direction="row" justify="center">
+                <Box className="box-180-50" />
+                <Box className="box-180-50" />
+                <Box className="box-180-50" />
+                <Box className="box-180-50" />
+            </Box>
+        );
+
+        const style = wrapper.find('.test').at(2).prop('style');
+        const {justifyContent} = style;
+        assert(justifyContent === "center")
+    });
 });


### PR DESCRIPTION
When wrap and spacing setted, the outer `next-box 1` will not have the style `justify-content:center` since it is filtered by using `innerProps` which is meant to be kept for inner `next-box 2`. Meanwhile, as the "between" div doesn't set its width, the inner `next-box 2` can not calculate its x axis width, so its `justify-content` won't work.

```html
<div class="next-box 1" style="padding: 20px;">
  <div class="between" style="margin: -0.5px; overflow: hidden;">
    <div class="next-box 2" style="flex-flow: row wrap;justify-content: center;">
      <div class="next-box box-180-50" style="flex-flow: column nowrap; margin: 0.5px;"></div>
      <div class="next-box box-180-50" style="flex-flow: column nowrap; margin: 0.5px;"></div>
      <div class="next-box box-180-50" style="flex-flow: column nowrap; margin: 0.5px;"></div>
      <div class="next-box box-180-50" style="flex-flow: column nowrap; margin: 0.5px;"></div>
    </div>
  </div>
</div>
```

This issue has two solutions: 
1. set width of the "between" div;
2. move `justify-content` from inner `next-box 2` to outer `next-box 1`whose x aixs width can be calculated.

Here we choose solution 2. Leave out the `justifyContent` from innerProps so as to move `justify-content`  to outer `next-box 1`.
