### PR TITLE
fix(Breadcrumb): separator icon's vertical align should be middle

### DIFF
--- a/src/breadcrumb/scss/mixin.scss
+++ b/src/breadcrumb/scss/mixin.scss
@@ -58,6 +58,9 @@
         line-height: $height;
 
         .#{$css-prefix}icon {
+            &:before {
+                display: block;
+            }
             @include icon-size($separatorSize);
         }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16127112/82549573-b9ea7380-9b8f-11ea-847c-1a170d115fda.png)

======>

![image](https://user-images.githubusercontent.com/16127112/82549611-c79ff900-9b8f-11ea-8059-76286afe090b.png)
