### PR TITLE
fix(Search): fix Incompatible units on sass compile

### DIFF
--- a/src/search/main.scss
+++ b/src/search/main.scss
@@ -114,8 +114,8 @@
             }
 
             .#{$css-prefix}input {
-                border-top-left-radius: $search-normal-corner - $search-normal-primary-border-width;
-                border-bottom-left-radius: $search-normal-corner - $search-normal-primary-border-width;
+                border-top-left-radius: calc($search-normal-corner - $search-normal-primary-border-width);
+                border-bottom-left-radius: calc($search-normal-corner - $search-normal-primary-border-width);
             }
         }
 
@@ -151,8 +151,8 @@
             }
 
             .#{$css-prefix}input {
-                border-top-left-radius: $search-normal-corner - $search-normal-secondary-border-width;
-                border-bottom-left-radius: $search-normal-corner - $search-normal-secondary-border-width;
+                border-top-left-radius: calc($search-normal-corner - $search-normal-secondary-border-width);
+                border-bottom-left-radius: calc($search-normal-corner - $search-normal-secondary-border-width);
             }
         }
 
@@ -188,8 +188,8 @@
             }
 
             .#{$css-prefix}input {
-                border-top-left-radius: $search-normal-corner - $search-normal-normal-border-width;
-                border-bottom-left-radius: $search-normal-corner - $search-normal-normal-border-width;
+                border-top-left-radius: calc($search-normal-corner - $search-normal-normal-border-width);
+                border-bottom-left-radius: calc($search-normal-corner - $search-normal-normal-border-width);
             }
         }
 

--- a/src/search/rtl.scss
+++ b/src/search/rtl.scss
@@ -48,8 +48,8 @@
             .#{$css-prefix}input {
                 border-top-left-radius: 0;
                 border-bottom-left-radius: 0;
-                border-top-right-radius: $search-normal-corner - $search-normal-primary-border-width;
-                border-bottom-right-radius: $search-normal-corner - $search-normal-primary-border-width;
+                border-top-right-radius: calc($search-normal-corner - $search-normal-primary-border-width);
+                border-bottom-right-radius: calc($search-normal-corner - $search-normal-primary-border-width);
             }
             @include search-type-color-rtl(
                 $search-normal-primary-color,
@@ -65,8 +65,8 @@
             .#{$css-prefix}input {
                 border-top-left-radius: 0;
                 border-bottom-left-radius: 0;
-                border-top-right-radius: $search-normal-corner - $search-normal-primary-border-width;
-                border-bottom-right-radius: $search-normal-corner - $search-normal-primary-border-width;
+                border-top-right-radius: calc($search-normal-corner - $search-normal-primary-border-width);
+                border-bottom-right-radius: calc($search-normal-corner - $search-normal-primary-border-width);
             }
             @include search-type-color-rtl(
                 $search-normal-secondary-color,
@@ -82,8 +82,8 @@
             .#{$css-prefix}input {
                 border-top-left-radius: 0;
                 border-bottom-left-radius: 0;
-                border-top-right-radius: $search-normal-corner - $search-normal-primary-border-width;
-                border-bottom-right-radius: $search-normal-corner - $search-normal-primary-border-width;
+                border-top-right-radius: calc($search-normal-corner - $search-normal-primary-border-width);
+                border-bottom-right-radius: calc($search-normal-corner - $search-normal-primary-border-width);
             }
             @include search-type-color-rtl(
                 $search-normal-normal-color,


### PR DESCRIPTION
sass编译的时候，百分值和长度值进行运算的时候需要使用calc方法，或者会报错