### PR TITLE
fix(Tab): narrow close icon hot area

### DIFF
--- a/src/tab/scss/mixin.scss
+++ b/src/tab/scss/mixin.scss
@@ -169,7 +169,7 @@
         }
 
         .#{$css-prefix}tabs-tab-close {
-            padding-left: $close-icon-margin-left;
+            margin-left: $close-icon-margin-left;
             @include icon-size($close-icon-size);
         }
     }


### PR DESCRIPTION
fix #2061 
缩小关闭叉号icon点击的热区

将文案和叉号icon之间的空白 从padding换成margin
为padding时，点击空白处也会将tab关闭，在切换tab的时候十分容易造成误点，给用户造成困惑。
改成margin后，样式不变，点击空白处不会关闭tab。