### PR TITLE
fix(NumberPicker): add alwaysShowTrigger in types/number-picker

### DIFF
--- a/types/number-picker/index.d.ts
+++ b/types/number-picker/index.d.ts
@@ -125,9 +125,10 @@ export interface NumberPickerProps extends HTMLAttributesWeak, CommonProps {
      * 减少按钮的props
      */
     downBtnProps?: ButtonProps;
+    /**
+     * 控制按钮一直显示、隐藏
+     */
+    alwaysShowTrigger?: boolean;
 }
 
-export default class NumberPicker extends React.Component<
-    NumberPickerProps,
-    any
-> {}
+export default class NumberPicker extends React.Component<NumberPickerProps, any> {}


### PR DESCRIPTION
number picker的ts中，props的interface缺少了alwaysShowTrigger的字段