### PR TITLE
fix(Badge): fix count scroll position

### DIFF
--- a/src/badge/sup.jsx
+++ b/src/badge/sup.jsx
@@ -103,9 +103,7 @@ class Sup extends Component {
         const supNode = this.supEl;
 
         if (supNode && dom.hasClass(supNode, `${prefix}badge-count`)) {
-            let scrollNums = supNode.querySelectorAll(
-                `.${prefix}badge-scroll-number-only`
-            );
+            let scrollNums = supNode.querySelectorAll(`.${prefix}badge-scroll-number-only`);
 
             if (scrollNums.length) {
                 const height = window.getComputedStyle(supNode).height;
@@ -114,7 +112,7 @@ class Sup extends Component {
 
                 getDigitArray(count).forEach((digit, i) => {
                     const position = this.getPositionByDigit(digit, i, revert);
-                    const transformTo = -position * parseInt(height, 10);
+                    const transformTo = -position * parseFloat(height);
 
                     removeTransition =
                         removeTransition ||
@@ -169,15 +167,7 @@ class Sup extends Component {
     };
 
     render() {
-        const {
-            prefix,
-            count,
-            showZero,
-            overflowCount,
-            dot,
-            style,
-            content,
-        } = this.props;
+        const { prefix, count, showZero, overflowCount, dot, style, content } = this.props;
 
         const supClasses = classNames(`${prefix}badge-scroll-number`, {
             [`${prefix}badge-count`]: !!count || (count === 0 && showZero),
@@ -189,14 +179,9 @@ class Sup extends Component {
         const show = dot || count > 0 || (count === 0 && showZero) || content;
 
         if (count > 0 || (count === 0 && showZero)) {
-            const realCount =
-                overflowCount > 0 && count > overflowCount
-                    ? `${overflowCount}+`
-                    : count;
+            const realCount = overflowCount > 0 && count > overflowCount ? `${overflowCount}+` : count;
 
-            children = isNaN(realCount)
-                ? realCount
-                : Sup.renderNumber(prefix, count);
+            children = isNaN(realCount) ? realCount : Sup.renderNumber(prefix, count);
         } else if (content) {
             children = content;
         }
@@ -207,11 +192,7 @@ class Sup extends Component {
             leave: 'zoomOut',
         };
 
-        const wrapper = support.animation ? (
-            <Animate animation={animation} />
-        ) : (
-            <span />
-        );
+        const wrapper = support.animation ? <Animate animation={animation} /> : <span />;
         const element = show ? (
             <sup ref={this.saveRef} className={supClasses} style={style}>
                 {children}


### PR DESCRIPTION

因为种种奇怪的原因（比如浏览器缩放），浏览器`window.getComputedStyle(supNode).height`返回的可能不是一个整数，比如我们期望返回`18px`然而它返回`17.997px`：

![image](https://user-images.githubusercontent.com/18747423/92214355-89241500-eec6-11ea-9148-cbcc3c04b392.png)

parseInt以后会变成17，原本很小的精度丢失被放大，导致badge的滚动位置计算出现较大误差：
![image](https://user-images.githubusercontent.com/18747423/92215090-de602680-eec6-11ea-8dc5-5c5796a1f424.png)
