### PR TITLE
fix(Select): placeholder in ie11

### DIFF
--- a/docs/field/index.md
+++ b/docs/field/index.md
@@ -21,6 +21,7 @@
 - initValue 类似组件的 defaultValue 只有在组件第一次render的时候才生效(ajax 异步调用设置 initValue 可能已经错过了第一次render)
 - autoUnmount 默认打开的，如果需要保留会 `自动卸载的组件` 数据请关闭此项
 - `parseName=true` 可以通过 `getValues` 获取到结构化的数据, 但是 getValue 还是必须传完整 key 值
+- `PureComponent` 中无法使用，除非你开启 `forceUpdate` 功能，但是会带来性能问题
 
 ### 基本使用
 

--- a/src/select/main.scss
+++ b/src/select/main.scss
@@ -156,10 +156,6 @@
                 opacity: 0;
                 filter: alpha(opacity=0); /* for IE 9 */
             }
-
-            #{$select-prefix}-trigger-search input {
-                color: $color-transparent;
-            }
         }
 
         #{$select-prefix}-values {
@@ -266,13 +262,16 @@
         }
     }
 
+
+    /* 在搜索框未激活时，将 input 的 color 置为透明 */
+    /* ISSUE: 在 IE11 中，<input readonly/> 仍然会显示光标, 要隐藏掉 */
+    /*
     &.#{$css-prefix}no-search {
-        /* 在搜索框未激活时，将 input 的 color 置为透明 */
-        /* ISSUE: 在 firefox 中，readonly 的 input 仍然会显示光标 */
         #{$select-prefix}-trigger-search input {
             color: $color-transparent;
         }
     }
+    */
 
     &-auto-complete {
         width: 160px;
@@ -460,10 +459,6 @@
                 #{$select-prefix}-values > em + #{$select-prefix}-trigger-search {
                     filter: alpha(opacity=0); /* for IE 9 */
                     font-size: 0;
-                }
-
-                #{$select-prefix}-trigger-search input {
-                    color: inherit;
                 }
             }
         }


### PR DESCRIPTION
ie 下 readonly 的 input 会带有 输入标识，目前暂时无法解决。

用 unselectable 会去除光标，但是 placeholder 也会丢失。对比起来觉得还是 placeholder 更重要。