### PR TITLE
feat(Menu): add selectable classnames

### DIFF
--- a/src/input/group.jsx
+++ b/src/input/group.jsx
@@ -52,11 +52,13 @@ class Group extends React.Component {
             addonBeforeClassName,
             addonAfterClassName,
             rtl,
+            disabled,
             ...others
         } = this.props;
 
         const cls = classNames({
             [`${prefix}input-group`]: true,
+            [`${prefix}disabled`]: disabled,
             [className]: !!className,
         });
 
@@ -70,21 +72,12 @@ class Group extends React.Component {
             [addonAfterClassName]: addonAfterClassName,
         });
 
-        const before = addonBefore ? (
-            <span className={beforeCls}>{addonBefore}</span>
-        ) : null;
+        const before = addonBefore ? <span className={beforeCls}>{addonBefore}</span> : null;
 
-        const after = addonAfter ? (
-            <span className={afterCls}>{addonAfter}</span>
-        ) : null;
+        const after = addonAfter ? <span className={afterCls}>{addonAfter}</span> : null;
 
         return (
-            <span
-                {...others}
-                dir={rtl ? 'rtl' : undefined}
-                className={cls}
-                style={style}
-            >
+            <span {...others} disabled={disabled} dir={rtl ? 'rtl' : undefined} className={cls} style={style}>
                 {before}
                 {children}
                 {after}

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -132,40 +132,17 @@ export default class Input extends Base {
     }
 
     renderControl() {
-        const {
-            hasClear,
-            readOnly,
-            state,
-            prefix,
-            hint,
-            extra,
-            locale,
-        } = this.props;
+        const { hasClear, readOnly, state, prefix, hint, extra, locale } = this.props;
 
         const lenWrap = this.renderLength();
 
         let stateWrap = null;
         if (state === 'success') {
-            stateWrap = (
-                <Icon
-                    type="success-filling"
-                    className={`${prefix}input-success-icon`}
-                />
-            );
+            stateWrap = <Icon type="success-filling" className={`${prefix}input-success-icon`} />;
         } else if (state === 'loading') {
-            stateWrap = (
-                <Icon
-                    type="loading"
-                    className={`${prefix}input-loading-icon`}
-                />
-            );
+            stateWrap = <Icon type="loading" className={`${prefix}input-loading-icon`} />;
         } else if (state === 'warning') {
-            stateWrap = (
-                <Icon
-                    type="warning"
-                    className={`${prefix}input-warning-icon`}
-                />
-            );
+            stateWrap = <Icon type="warning" className={`${prefix}input-warning-icon`} />;
         }
 
         let clearWrap = null;
@@ -175,15 +152,10 @@ export default class Input extends Base {
             let hintIcon = null;
             if (hint) {
                 if (typeof hint === 'string') {
-                    hintIcon = (
-                        <Icon type={hint} className={`${prefix}input-hint`} />
-                    );
+                    hintIcon = <Icon type={hint} className={`${prefix}input-hint`} />;
                 } else if (isValidElement(hint)) {
                     hintIcon = cloneElement(hint, {
-                        className: classNames(
-                            hint.props.className,
-                            `${prefix}input-hint`
-                        ),
+                        className: classNames(hint.props.className, `${prefix}input-hint`),
                     });
                 } else {
                     hintIcon = hint;
@@ -304,13 +276,13 @@ export default class Input extends Base {
             rtl,
         } = this.props;
 
-        const hasAddon =
-            addonBefore || addonAfter || addonTextBefore || addonTextAfter;
+        const hasAddon = addonBefore || addonAfter || addonTextBefore || addonTextAfter;
         const cls = classNames(this.getClass(), {
             [`${prefix}${size}`]: true,
             [`${prefix}hidden`]: this.props.htmlType === 'hidden',
             [`${prefix}noborder`]: !hasBorder || this.props.htmlType === 'file',
             [`${prefix}input-group-auto-width`]: hasAddon,
+            [`${prefix}disabled`]: disabled,
             [className]: !!className && !hasAddon,
         });
 
@@ -336,10 +308,7 @@ export default class Input extends Base {
         const dataProps = obj.pickAttrsWith(this.props, 'data-');
         // Custom props are transparently transmitted to the core input node by default
         // 自定义属性默认透传到核心node节点：input
-        const others = obj.pickOthers(
-            Object.assign({}, dataProps, Input.propTypes),
-            this.props
-        );
+        const others = obj.pickOthers(Object.assign({}, dataProps, Input.propTypes), this.props);
 
         if (isPreview) {
             const { value } = props;
@@ -378,12 +347,7 @@ export default class Input extends Base {
         );
 
         const inputWrap = (
-            <span
-                {...dataProps}
-                dir={rtl ? 'rtl' : undefined}
-                className={cls}
-                style={hasAddon ? undefined : style}
-            >
+            <span {...dataProps} dir={rtl ? 'rtl' : undefined} className={cls} style={hasAddon ? undefined : style}>
                 {this.renderLabel()}
                 {this.renderInner(innerBefore, innerBeforeCls)}
                 {inputRender(inputEl)}
@@ -411,6 +375,7 @@ export default class Input extends Base {
                     {...dataProps}
                     className={className}
                     style={style}
+                    disabled={disabled}
                     addonBefore={addonBefore || addonTextBefore}
                     addonBeforeClassName={addonBeforeCls}
                     addonAfter={addonAfter || addonTextAfter}

--- a/src/menu/view/menu.jsx
+++ b/src/menu/view/menu.jsx
@@ -890,6 +890,7 @@ class Menu extends Component {
             [`${prefix}hoz`]: direction === 'hoz',
             [`${prefix}menu-embeddable`]: embeddable,
             [`${prefix}menu-nowrap`]: hozInLine,
+            [`${prefix}menu-selectable-${selectMode}`]: selectMode,
             [className]: !!className,
         });
 

--- a/src/search/Search.jsx
+++ b/src/search/Search.jsx
@@ -158,10 +158,7 @@ class Search extends React.Component {
         super(props);
 
         const value = 'value' in props ? props.value : props.defaultValue;
-        const filterValue =
-            'filterValue' in props
-                ? props.filterValue
-                : props.defaultFilterValue;
+        const filterValue = 'filterValue' in props ? props.filterValue : props.defaultFilterValue;
 
         this.state = {
             value: typeof value === 'undefined' ? '' : value,
@@ -175,17 +172,12 @@ class Search extends React.Component {
         const nextState = {};
         if ('value' in nextProps && nextProps.value !== prevState.value) {
             const value = nextProps.value;
-            nextState.value =
-                value === undefined || value === null ? '' : nextProps.value;
+            nextState.value = value === undefined || value === null ? '' : nextProps.value;
         }
 
-        if (
-            'filterValue' in nextProps &&
-            nextProps.filterValue !== prevState.filterValue
-        ) {
+        if ('filterValue' in nextProps && nextProps.filterValue !== prevState.filterValue) {
             const filterValue = nextProps.filterValue;
-            nextState.filterValue =
-                filterValue === undefined ? '' : filterValue;
+            nextState.filterValue = filterValue === undefined ? '' : filterValue;
         }
 
         if (Object.keys(nextState).length > 0) {
@@ -289,6 +281,7 @@ class Search extends React.Component {
             [`${prefix}search-${shape}`]: true,
             [`${prefix}${type}`]: type,
             [`${prefix}${size}`]: size,
+            [`${prefix}disabled`]: !!disabled,
             [className]: !!className,
         });
 
@@ -308,18 +301,15 @@ class Search extends React.Component {
                 [`${prefix}search-symbol-icon`]: !iconsSearch,
             });
             hasIcon &&
-                (searchIcon = React.cloneElement(
-                    iconsSearch || <Icon type="search" />,
-                    {
-                        role: 'button',
-                        'aria-disabled': disabled,
-                        'aria-label': locale.buttonText,
-                        ...buttonProps,
-                        className: cls,
-                        onClick: this.onSearch,
-                        onKeyDown: this.onKeyDown,
-                    }
-                ));
+                (searchIcon = React.cloneElement(iconsSearch || <Icon type="search" />, {
+                    role: 'button',
+                    'aria-disabled': disabled,
+                    'aria-label': locale.buttonText,
+                    ...buttonProps,
+                    className: cls,
+                    onClick: this.onSearch,
+                    onKeyDown: this.onKeyDown,
+                }));
         } else {
             const cls = classNames({
                 [`${prefix}search-btn`]: true,
@@ -336,19 +326,8 @@ class Search extends React.Component {
                     onClick={this.onSearch}
                     onKeyDown={this.onKeyDown}
                 >
-                    {hasIcon
-                        ? iconsSearch || (
-                              <Icon
-                                  type="search"
-                                  className={`${prefix}search-symbol-icon`}
-                              />
-                          )
-                        : null}
-                    {searchText ? (
-                        <span className={`${prefix}search-btn-text`}>
-                            {searchText}
-                        </span>
-                    ) : null}
+                    {hasIcon ? iconsSearch || <Icon type="search" className={`${prefix}search-symbol-icon`} /> : null}
+                    {searchText ? <span className={`${prefix}search-btn-text`}>{searchText}</span> : null}
                 </Button>
             );
         }
@@ -405,17 +384,8 @@ class Search extends React.Component {
         );
 
         return (
-            <span
-                className={cls}
-                style={style}
-                {...dataAttr}
-                dir={rtl ? 'rtl' : undefined}
-            >
-                {searchBtn ? (
-                    <Group addonAfter={searchBtn}>{left}</Group>
-                ) : (
-                    left
-                )}
+            <span className={cls} style={style} {...dataAttr} dir={rtl ? 'rtl' : undefined}>
+                {searchBtn ? <Group addonAfter={searchBtn}>{left}</Group> : left}
             </span>
         );
     }


### PR DESCRIPTION
我们这边对于可选择的menu（即带有✔️符号的menu），需要做一些样式覆盖，但是目前没有可靠选择器能够选中”可选择的menu“。