### PR TITLE
feat(ResponsiveGrid): support ie11 for css grid

### DIFF
--- a/src/form/form.jsx
+++ b/src/form/form.jsx
@@ -138,6 +138,8 @@ export default class Form extends React.Component {
          * 是否使用 label 替换校验信息的 name 字段
          */
         useLabelForErrorMessage: PropTypes.bool,
+        // 在 responsive模式下，透传给 ResponsiveGrid的， 表示 每个 cell 之间的间距， [bottom&top, right&left]
+        gap: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.number), PropTypes.number]),
     };
 
     static defaultProps = {
@@ -234,6 +236,7 @@ export default class Form extends React.Component {
             isPreview,
             component: Tag,
             responsive,
+            gap,
         } = this.props;
 
         const formClassName = classNames({
@@ -256,7 +259,7 @@ export default class Form extends React.Component {
                 dir={rtl ? 'rtl' : undefined}
                 onSubmit={onSubmit}
             >
-                {responsive ? <RGrid>{newChildren}</RGrid> : newChildren}
+                {responsive ? <RGrid gap={gap}>{newChildren}</RGrid> : newChildren}
             </Tag>
         );
     }

--- a/src/responsive-grid/main.scss
+++ b/src/responsive-grid/main.scss
@@ -10,4 +10,8 @@
 #{$responsive-grid-prefix} {
     @include box-sizing;
     display: grid;
+
+    &-ie {
+        display: block;
+    }
 }

--- a/types/form/index.d.ts
+++ b/types/form/index.d.ts
@@ -482,6 +482,8 @@ export interface FormProps extends HTMLAttributesWeak, CommonProps {
      */
     component?: string | (() => void);
     responsive?: boolean;
+    // 在 responsive模式下，透传给 ResponsiveGrid的， 表示 每个 cell 之间的间距， [bottom&top, right&left]
+    gap?: number | Array<number>;
     isPreview?: boolean;
     renderPreview?: (values: number | string | data | Array<number | string | data>, props: any) => any
 }


### PR DESCRIPTION
## 问题
ResponsiveGrid 不支持IE

## 原因
ResponsiveGrid采用css grid能力实现，由于IE11浏览器的Grid解析内核与现代浏览器不同，一些需要大量浏览器绘制计算的能力IE11不具备，例如：
- 自动布局能力：现代浏览器下，给css grid的children 设置占据几行几列，他们会自动在剩余空间进行排布。而在IE11下虽然有类似的占据几行几列的API，但是它没有自动在剩余空间进行排布的能力，用户只能给不同位置的child设置不同的行列的起始位置，这一功能需要大量计算，也就是说如果组件想要兼容IE11，就相当于把现代浏览器的排布能力在组件层面实现了一遍。
- 元素间的间距gap：IE11没有类似API，不支持设置子元素间的gap
- 其他相对来说不方便，但是有解决方案的点，例如repeat(1fr, 4) 可以写成 1fr 1fr 1fr 1fr

上述问题中，前两个比较严重，只通过简单的autoprefixer没办法兼容IE11。   参考 https://stackoverflow.com/questions/45786788/css-grid-layout-not-working-in-ie11-even-with-prefixes

## 解决方案
从原因上可以看出，继续在IE的css-grid环境下进行各种优化走不通。综合考虑之后准备通过Flex布局 + margin来实现类似的功能，语义逻辑上比较奇怪，但是能力基本匹配，具体方案见本PR。

大概率上没有问题，但是可能会有不可预期的样式问题，例如通过Flex在实现gap的时候，用到了3层元素来hack，设置了overflow hidden，所以followTrigger的弹窗可能会有问题

