### PR TITLE
fix(Search): correct usage of this and avoid warning for esm bundle

### DIFF
--- a/src/search/index.jsx
+++ b/src/search/index.jsx
@@ -3,7 +3,7 @@ import Search from './Search';
 
 export default ConfigProvider.config(Search, {
     transfrom: /* istanbul ignore next */ (props, deprecated) => {
-        const { onInputFocus, overlayVisible, combox, ...others } = this.props;
+        const { onInputFocus, overlayVisible, combox, ...others } = props;
 
         const newprops = others;
 
@@ -11,7 +11,7 @@ export default ConfigProvider.config(Search, {
             deprecated('onInputFocus', 'onFocus', 'Search');
             newprops.onFocus = onInputFocus;
         }
-        if ('overlayVisible' in this.props) {
+        if ('overlayVisible' in props) {
             deprecated('overlayVisible', 'visible', 'Search');
             newprops.visible = overlayVisible;
         }


### PR DESCRIPTION
```jsx
// src/search/index.jsx
export default ConfigProvider.config(Search, {
  transfrom: (props, deprecated) => {
     const { onInputFocus, overlayVisible, combox, ...others } = this.props; // this use as gloablThis
  }
});
```

ESM bundle:

![image](https://user-images.githubusercontent.com/17971291/95809339-19187280-0d41-11eb-96f2-8a3a00159d82.png)

The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten.

![image](https://user-images.githubusercontent.com/17971291/95809372-2f263300-0d41-11eb-84c5-37c8b6a7ebcf.png)

This PR fixes the above warning.