### PR TITLE
fix(NumberPicker): fix unexpected scientific notation display,close#2243

### DIFF
--- a/src/number-picker/number-picker.jsx
+++ b/src/number-picker/number-picker.jsx
@@ -199,6 +199,23 @@ class NumberPicker extends React.Component {
 
             // in case of autoCorrect ('0.'=>0, '0.0'=>0) , we have these steps
             if (value) {
+                const precisionCurrent = value.length - value.indexOf('.') - 1;
+                const precisionSet = this.getPrecision();
+                const dotNum = value.match(/\./g);
+                const dotIndex = value.indexOf('.');
+
+                // ignore more than one . or -, cut at second . or -
+                if (dotNum && dotNum.length > 1) value = value.substr(0, value.split('.', 2).join('.').length);
+                const minusNum = value.match(/-/g);
+                if (minusNum && minusNum.length > 1) value = value.substr(0, value.split('-', 2).join('.').length);
+
+                // ignore . when precision set 0
+                // leave out digits larger than precision set
+                if (dotIndex > -1) {
+                    if (precisionSet === 0) value = value.substr(0, dotIndex);
+                    else if (precisionCurrent > precisionSet) value = value.substr(0, dotIndex + 1 + precisionSet);
+                }
+
                 // ignore when input start form '-'
                 if (value === '-' || this.state.value === '-') {
                     this.setState({
@@ -279,14 +296,6 @@ class NumberPicker extends React.Component {
             }
             if (val > props.max) {
                 val = props.max;
-            }
-
-            // precision=2  and input from 1.99 to 1.999, should stay with 1.99 not 2
-            const strValue = `${val}`;
-            const pointPos = strValue.indexOf('.');
-            const cutPos = pointPos + 1 + this.getPrecision();
-            if (pointPos !== -1 && strValue.length > cutPos) {
-                val = Number(strValue.substr(0, cutPos));
             }
         } else {
             val = this.state.value;

--- a/test/number-picker/index-spec.js
+++ b/test/number-picker/index-spec.js
@@ -84,6 +84,74 @@ describe('number-picker', () => {
             done();
         });
 
+        it('should leave out digits larger than precision set', done => {
+            let wrapper = mount(
+                <NumberPicker defaultValue={0} precision={1}/>
+            );
+
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: '0.34' } });
+            assert(wrapper.find('input').prop('value') === 0.3);
+
+            wrapper = mount(
+                <NumberPicker defaultValue={0} />
+            );
+
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: '0.' } });
+            assert(wrapper.find('input').prop('value') === 0);
+
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: '0.24' } });
+            assert(wrapper.find('input').prop('value') === 0);
+
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: '0.2.4' } });
+            assert(wrapper.find('input').prop('value') === 0);
+
+            done();
+        })
+
+        it('should ignore more than one . or -, cut at second . or -', done => {
+            let wrapper = mount(
+                <NumberPicker defaultValue={0} precision={2}/>
+            );
+
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: '0.3.4' } });
+            assert(wrapper.find('input').prop('value') === 0.3);
+
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: '-0.3-4' } });
+            assert(wrapper.find('input').prop('value') === -0.3);
+
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: '-1.345-4' } });
+            assert(wrapper.find('input').prop('value') === -1.34);
+
+            const onChange = value => {
+                assert(value === 0);
+            };
+            wrapper = mount(
+                <NumberPicker defaultValue={0} precision={2} onChange={onChange}/>
+            );
+
+            wrapper
+                .find('input')
+                .simulate('change', { target: { value: '-0.-3.4' } });
+            assert(wrapper.find('input').prop('value') === '-0.');
+            assert(!onChange.calledOnce);
+
+            done();
+        })
+
         it('should work with value and onChange under control', done => {
             class App extends React.Component {
                 state = {
@@ -152,7 +220,7 @@ describe('number-picker', () => {
         it('should support input with -/-0/-0./0./0.0 ', () => {
             const onChange = sinon.spy();
             const wrapper = mount(
-                <NumberPicker defaultValue={0} onChange={onChange} />
+                <NumberPicker defaultValue={0} onChange={onChange} precision={1}/>
             );
 
             wrapper


### PR DESCRIPTION
修复以下问题：

1. 设置小数点后输入位数不可超过precision，否则截断，未设置则precision=0。修复小数点后0可以无限输入的问题，解决小数点后0输入过长后键入非0数字会转科学计数法的问题；
2. 不允许输入多于一个.或-字符，若粘贴字符串中有多于一个，则从第二个处截断。