### PR TITLE
fix(NumberPicker): fix trigger height problem in firefox, close#2281

### DIFF
--- a/src/number-picker/main.scss
+++ b/src/number-picker/main.scss
@@ -21,6 +21,7 @@
 
             .#{$css-prefix}input-control {
                 padding-right: 0;
+                height: 100%;
             }
         }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65325063/97539215-8f34fe80-19fc-11eb-91ee-8756d6157ed9.png)

number-picker 中按钮控制（extra元素）中 .next-input-control未设置height，
chrome中会以父元素高度为基准自动计算，而firefox中则不会，
导致firefox中子元素.next-number-picker-handler的height: 100%的高度计算出错，未撑满整个NumberPicker