### PR TITLE
fix: the ".next-icon.next-small" css selector with 16px font-size wil…

### DIFF
--- a/src/table/base/sort.jsx
+++ b/src/table/base/sort.jsx
@@ -45,7 +45,7 @@ export default class Sort extends React.Component {
                     {sortIcons ? (
                         sortIcons[sortOrder]
                     ) : (
-                        <Icon rtl={rtl} type={map[sortOrder]} size="small" />
+                        <Icon rtl={rtl} type={map[sortOrder]} size="xs" />
                     )}
                 </a>
             );


### PR DESCRIPTION
…l conflict with the ".next-table-sort .next-icon" css selector with 12px font-size

![](https://gw.alicdn.com/tfs/TB1PWWtntTfau8jSZFwXXX1mVXa-794-366.png) 

Normalizing the icon style to avoid the bug as the picture above.(Although I haven't understood why the css selector above cascaded the selector below)