### PR TITLE
fix(Select): google translate bug fix #2424

### DIFF
--- a/src/select/select.jsx
+++ b/src/select/select.jsx
@@ -1053,11 +1053,22 @@ class Select extends Base {
             [`${prefix}select-compact`]: !isSingle && tagInline,
         });
         const title = typeof valueNodes === 'string' ? valueNodes : '';
-        const searchInput = [isSingle && valueNodes ? <em title={title} key="select-value">{valueNodes}</em> : valueNodes];
+        const searchInput = [
+            isSingle && valueNodes ? (
+                <em title={title} key="select-value">
+                    {valueNodes}
+                </em>
+            ) : (
+                valueNodes
+            ),
+        ];
         const triggerSearch = (
             <span key="trigger-search" className={`${prefix}select-trigger-search`}>
                 {inputEl}
-                <span aria-hidden>{mirrorText || placeholder}&nbsp;</span>
+                <span aria-hidden>
+                    <span>{mirrorText || placeholder}</span>
+                    <span>&nbsp;</span>
+                </span>
             </span>
         );
 


### PR DESCRIPTION
google translate 翻译的时候会把文字转为 font 标签，dom 结构变化 unmount 的时候找不到元素导致页面 crash

可以在文字上面包裹 span 避免此 bug

<span aria-hidden>{mirrorText || placeholder}&nbsp;</span>
translate 后 变成

image

文字包裹下 span 可解，不要出现一半文字一半span

详细见 issue #2424