### PR TITLE
Feat: add focus state for Input

### DIFF
--- a/src/input/main.scss
+++ b/src/input/main.scss
@@ -195,6 +195,7 @@
 
     &.#{$css-prefix}noborder {
         border: none;
+        box-shadow: none;
     }
 
     &-control {

--- a/src/input/scss/variable.scss
+++ b/src/input/scss/variable.scss
@@ -46,7 +46,7 @@ $input-focus-bg-color: $color-white !default;
 
 /// shadow
 /// @namespace statement/focus
-$input-focus-shadow-spread: $line-zero !default;
+$input-focus-shadow-spread: $line-2 !default;
 
 /// border
 /// @namespace size/bounding


### PR DESCRIPTION
为了支持精致度升级，以及DatePicker2的加入，所有Input都应该设置下focus时的高亮状态，例如：
![image](https://user-images.githubusercontent.com/10049465/101020335-506d0800-35a9-11eb-9369-40e603007d86.png)

因此把基础组件的默认样式改掉，影响的范围是：没有设置过主题包的用户。

对于所有设置过主题包的用户而言，他们的样式数据存储在主题包里，甚至不用拆分变量，完美！
