### PR TITLE
feat(NumberPicker): support ref.getInputNode

### DIFF
--- a/src/number-picker/index.jsx
+++ b/src/number-picker/index.jsx
@@ -10,4 +10,5 @@ export default ConfigProvider.config(NumberPicker, {
 
         return props;
     },
+    exportNames: ['getInputNode'],
 });

--- a/src/number-picker/number-picker.jsx
+++ b/src/number-picker/number-picker.jsx
@@ -465,6 +465,10 @@ class NumberPicker extends React.Component {
         this.inputRef = ref;
     }
 
+    getInputNode() {
+        return this.inputRef;
+    }
+
     handleMouseDown(e) {
         e.preventDefault();
     }


### PR DESCRIPTION
过去NumberPicker无法获取DOM节点