### PR TITLE
fix: 15px padding-right to body for debouncing added by overlay won't…

### DIFF
--- a/src/overlay/overlay.jsx
+++ b/src/overlay/overlay.jsx
@@ -507,7 +507,7 @@ class Overlay extends Component {
                     const style = {
                         overflow: bodyOverflow,
                     };
-                    if (hasScroll()) {
+                    if (bodyPaddingRight !== undefined) {
                         style.paddingRight = bodyPaddingRight;
                     }
 

--- a/test/overlay/index-spec.js
+++ b/test/overlay/index-spec.js
@@ -19,10 +19,6 @@ const { hasClass } = dom;
 const { Popup } = Overlay;
 const delay = time => new Promise(resolve => setTimeout(resolve, time));
 const scrollbarWidth = dom.scrollbar().width;
-const hasScroll = () => {
-    const doc = document.documentElement;
-    return doc.scrollHeight > doc.clientHeight && scrollbarWidth > 0;
-};
 
 const render = element => {
     let inc;
@@ -77,7 +73,7 @@ class OverlayControlDemo extends React.Component {
         const { children, ...others } = this.props;
 
         return (
-            <div>
+            <div style={{ height: '110vh' }}>
                 <button
                     onClick={this.onClick}
                     ref={ref => {
@@ -364,16 +360,12 @@ describe('Overlay', () => {
 
             simulateEvent.simulate(btn, 'click');
             assert(document.body.style.overflowY === 'hidden');
-            if (hasScroll()) {
-                assert(document.body.style.paddingRight === `${scrollbarWidth}px`);
-            }
+            assert(document.body.style.paddingRight === `${scrollbarWidth}px`);
 
             simulateEvent.simulate(btn, 'click');
             yield delay(500);
             assert(!document.body.style.overflowY);
-            if (hasScroll()) {
-                assert(!document.body.style.paddingRight);
-            }
+            assert(!document.body.style.paddingRight);
         });
     });
 


### PR DESCRIPTION
… clean

Overlay组件在打开时如果当前页面存在滚动条，会为Body添加15px的padding防止页面抖动，由于此时滚动条已消失，Overlay关闭时没有走到hasScroll的条件分支将Padding清除掉