### PR TITLE
fix(Pagination): use inline-flex and margin instead of inline-block

### DIFF
--- a/src/pagination/main.scss
+++ b/src/pagination/main.scss
@@ -15,7 +15,8 @@
     }
 
     &-pages {
-        display: inline-block;
+        display: inline-flex;
+        align-items: center;
     }
 
     &-list {
@@ -32,6 +33,7 @@
     }
 
     & &-item {
+        margin-left: $s-1;
         &.#{$css-prefix}current {
             border-color: $pagination-item-current-border-color;
             background: $pagination-item-current-bg;
@@ -51,6 +53,7 @@
         display: inline-block;
         color: $pagination-ellipsis-color;
         vertical-align: top;
+        margin-right: $s-1;
     }
 
     &-display {
@@ -243,6 +246,14 @@
 
         &.#{$css-prefix}mini {
             @include mini-size($s-2);
+        }
+
+        #{$pagination-prefix}-ellipsis {
+            margin-right: $s-2;
+        }
+
+        #{$pagination-prefix}-item {
+            margin-left: $s-2;
         }
     }
 


### PR DESCRIPTION
The commit is to avoid hop when paginating.
Not sure whether it's elegant.
