### PR TITLE
fix(Form): add valueName

### DIFF
--- a/src/form/item.jsx
+++ b/src/form/item.jsx
@@ -209,6 +209,10 @@ export default class Item extends React.Component {
          * 表示是否显示 label 后面的冒号
          */
         colon: PropTypes.bool,
+        /**
+         * 子元素的 value 名称
+         */
+        valueName: PropTypes.string,
     };
 
     static defaultProps = {

--- a/types/form/index.d.ts
+++ b/types/form/index.d.ts
@@ -202,27 +202,42 @@ export interface ItemProps extends React.HTMLAttributes<HTMLElement>, CommonProp
      * 是否修改数据时自动触发校验
      */
     autoValidate?: boolean;
+
     /**
      * 在响应式布局下，且label在左边时，label的宽度是多少
      */
     labelWidth?: number | string;
+
     /**
      * 在响应式布局模式下，表单项占多少列
      */
     colSpan?: number;
+
     /**
      * 是否开启预览态
      */
     isPreview?: boolean;
+
     /**
      * 预览态模式下渲染的内容
      * @param {any} value 根据包裹的组件的 value 类型而决定
      */
-    renderPreview?: (values: number | string | data | Array<number | string | data>, props: any) => any
+    renderPreview?: (values: number | string | data | Array<number | string | data>, props: any) => any;
+
     /**
      * 是否使用 label 替换校验信息的 name 字段
      */
-    useLabelForErrorMessage?: boolean
+    useLabelForErrorMessage?: boolean;
+
+    /**
+     * 表示是否显示 label 后面的冒号
+     */
+    colon?: boolean;
+
+    /**
+     * 子元素的 value 名称
+     */
+    valueName?: string;
 }
 
 export class Item extends React.Component<ItemProps, any> {}


### PR DESCRIPTION
目前Form.Item上面写的valueName，因为没有在propTypes上面定义，会被应用到DOM上，导致react报错。

已本地验证，在propTypes上加上即可修复。

![95A58843-EF99-4644-9854-0F2B66D11265](https://user-images.githubusercontent.com/5326684/105141456-25784c80-5b34-11eb-957a-f46a161a416d.png)
