### PR TITLE
fix(Nav): fix compare 0 with 0px

### DIFF
--- a/src/nav/main.scss
+++ b/src/nav/main.scss
@@ -96,7 +96,8 @@ $nav-icononly-width: 58px;
                 height: $nav-hoz-item-hover-active-line;
             }
 
-            @if (get-compiling-value($nav-hoz-item-hover-active-line) != 0) {
+            @if (get-compiling-value($nav-hoz-item-hover-active-line) != 0 and
+            get-compiling-value($nav-hoz-item-hover-active-line) != 0px) {
                 &:hover:before {
                     width: 100%;
                     left: 0;
@@ -169,7 +170,8 @@ $nav-icononly-width: 58px;
                 width: $nav-ver-item-hover-active-line;
             }
 
-            @if (get-compiling-value($nav-ver-item-hover-active-line) != 0) {
+            @if (get-compiling-value($nav-ver-item-hover-active-line) != 0 and
+            get-compiling-value($nav-ver-item-hover-active-line) != 0px) {
                 &:hover:before {
                     height: 100%;
                     top: 0;


### PR DESCRIPTION
前一段时间fusion将很多`0`改成了`0px`，这些比较就会出错误。

有一个奇怪的地方是，我不知道为什么之前在`/dist/next.css`里面都没有暴露这些错误（不会进入if分支）；但是我在使用`babel-plugin-import`做样式按需加载的时候却会暴露这些错误（会进入if分支）。（都使用fusion默认主题）