### PR TITLE
fix(Upload): show error message when failed

### DIFF
--- a/src/upload/upload.jsx
+++ b/src/upload/upload.jsx
@@ -417,6 +417,7 @@ class Upload extends Base {
         Object.assign(targetItem, {
             state: 'error',
             error: err,
+            errorMsg: err && err.message,
             response,
         });
 


### PR DESCRIPTION
https://fusion.design/pc/component/basic/upload
上传失败是用 errorMsg 字段展示的，但是 onError 方法只写了 error，没写 errorMsg