### PR TITLE
fix(Step): stretch props warning

### DIFF
--- a/src/step/view/step-item.jsx
+++ b/src/step/view/step-item.jsx
@@ -6,7 +6,7 @@ import ResizeObserver from 'resize-observer-polyfill';
 import Icon from '../../icon';
 import Progress from '../../progress';
 import ConfigProvider from '../../config-provider';
-import { support, events, dom } from '../../util';
+import { support, events, dom, obj } from '../../util';
 
 /** Step.Item */
 class StepItem extends Component {
@@ -358,8 +358,9 @@ class StepItem extends Component {
             labelPlacement,
             rtl,
             onResize,
-            ...others
         } = this.props;
+
+        const others = obj.pickOthers(StepItem.propTypes, this.props);
 
         const stepCls = classNames({
             [`${prefix}step-item`]: true,

--- a/src/step/view/step.jsx
+++ b/src/step/view/step.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import React, { Component, Children } from 'react';
 import { polyfill } from 'react-lifecycles-compat';
-import { support, events, dom } from '../../util';
+import { support, events, dom, obj } from '../../util';
 
 const getHeight = el => dom.getStyle(el, 'height');
 const setHeight = (el, height) => dom.setStyle(el, 'height', height);
@@ -188,18 +188,8 @@ class Step extends Component {
 
     render() {
         // eslint-disable-next-line
-        const {
-            className,
-            current,
-            labelPlacement,
-            shape,
-            readOnly,
-            animation,
-            itemRender,
-            rtl,
-            stretch,
-            ...others
-        } = this.props;
+        const { className, current, labelPlacement, shape, readOnly, animation, itemRender, rtl, stretch } = this.props;
+        const others = obj.pickOthers(Step.propTypes, this.props);
         let { prefix, direction, children } = this.props;
         prefix = this.context.prefix || prefix;
         const { parentWidth, parentHeight } = this.state;


### PR DESCRIPTION
修复 Step stretch 属性透传到 dom warning
![image](https://user-images.githubusercontent.com/30346283/109279077-4713d480-7854-11eb-8007-9c6e41b15f83.png)
