### PR TITLE
docs(*): remove & in md title

### DIFF
--- a/docs/box/demo/align&justify.md
+++ b/docs/box/demo/align&justify.md
@@ -8,7 +8,7 @@
 - `direction` 为 `column` 时(默认值)， `justify` 控制垂直方向, `align` 控制水平方向。
 
 :::lang=en-us
-# align&justify
+# align and justify
 
 - order: 3
 

--- a/docs/box/demo/padding&margin.md
+++ b/docs/box/demo/padding&margin.md
@@ -5,7 +5,7 @@
 可以通过 `padding` `margin` 设置 `Box` 的内、外边距， `[10, 5]` 表示上下方向为10，左右方向为5。
 
 :::lang=en-us
-# Padding&Margin
+# Padding and Margin
 
 - order: 2
 

--- a/docs/dialog/demo/large-content.md
+++ b/docs/dialog/demo/large-content.md
@@ -1,4 +1,4 @@
-# 滚动条&isFullScreen
+# 滚动条 isFullScreen
 
 当对话框内容超出视窗时候，对话框会限制内容高度，显示滚动条，可以通过设置 `isFullScreen` 为 `true`，让对话框全屏显示不出现滚动条。注意，该属性仅在对话框垂直水平居中时生效，即 `align` 被设置为 `cc cc` 时。
 

--- a/docs/dialog/demo/withContext.md
+++ b/docs/dialog/demo/withContext.md
@@ -1,4 +1,4 @@
-# 国际化&withContext
+# 国际化 withContext
 
 - order: 7
 


### PR DESCRIPTION
md解析库默认会将title中&进行转义，避免demo展示转义后的符号，删除之。