### PR TITLE
feat(Switch): add loading & style refactor

### DIFF
--- a/docs/switch/demo/checked-children.md
+++ b/docs/switch/demo/checked-children.md
@@ -26,7 +26,7 @@ function onChange(checked) {
 ReactDOM.render(<div>
     <Switch checkedChildren="on" unCheckedChildren="off" onChange={onChange} />
     <br />
-    <Switch checkedChildren="已启用" unCheckedChildren="已关闭" onChange={onChange} style={{width: 76}}/>
+    <Switch checkedChildren="已启用" unCheckedChildren="已关闭" onChange={onChange}/>
     <br />
     <Switch checkedChildren={<Icon type="select" size="xs"/>} unCheckedChildren={<Icon type="close" size="xs"/>}  onChange={onChange} />
 </div>,

--- a/docs/switch/demo/loading.md
+++ b/docs/switch/demo/loading.md
@@ -1,0 +1,31 @@
+# 加载中
+
+- order: 0
+
+带加载中状态的switch
+
+:::lang=en-us
+# loading
+
+- order: 0
+
+Switch with loading
+
+:::
+
+---
+
+````jsx
+import { Switch } from '@alifd/next';
+
+ReactDOM.render(<div>
+    <Switch loading defaultChecked={false} /> <Switch loading defaultChecked />
+</div>,
+mountNode);
+````
+
+````css
+.large-width {
+    width: 100px;
+}
+````

--- a/docs/switch/theme/index.jsx
+++ b/docs/switch/theme/index.jsx
@@ -79,14 +79,32 @@ class ThemeDemo extends Component {
                         <Switch checked={false} {...props} />
                         <Switch checked={false} {...props} size="small" />
                     </DemoGroup>
-                    <DemoGroup label="On">
-                        <Switch checked {...props} />
-                        <Switch checked {...props} size="small" />
+                    <DemoGroup label="Hover Off">
+                        <Switch checked={false} className="hover" {...props} />
+                        <Switch checked={false} className="hover" {...props} size="small" />
+                    </DemoGroup>
+                    <DemoGroup label="Loading Off">
+                        <Switch checked={false} loading {...props} />
+                        <Switch checked={false} loading {...props} size="small" />
                     </DemoGroup>
                     <DemoGroup label="Disabled Off">
                         <Switch checked={false} disabled {...props} />
                         <Switch checked={false} {...props} disabled size="small" />
                     </DemoGroup>
+
+                    <DemoGroup label="On">
+                        <Switch checked {...props} />
+                        <Switch checked {...props} size="small" />
+                    </DemoGroup>
+                    <DemoGroup label="Hover On">
+                        <Switch checked {...props} className="hover" />
+                        <Switch checked {...props} className="hover" size="small" />
+                    </DemoGroup>
+                    <DemoGroup label="On & Loading">
+                        <Switch checked loading {...props} />
+                        <Switch checked loading {...props} size="small" />
+                    </DemoGroup>
+
                     <DemoGroup label="Disabled On">
                         <Switch checked disabled {...props} />
                         <Switch checked disabled {...props} size="small" />

--- a/src/switch/index.jsx
+++ b/src/switch/index.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { polyfill } from 'react-lifecycles-compat';
 import { KEYCODE } from '../util';
+import Icon from '../icon';
 import ConfigProvider from '../config-provider';
 import zhCN from '../locale/zh-cn';
 
@@ -50,6 +51,10 @@ class Switch extends React.Component {
          */
         disabled: PropTypes.bool,
         /**
+         * loading
+         */
+        loading: PropTypes.bool,
+        /**
          * switch的尺寸
          * @enumdesc 正常大小, 缩小版大小
          */
@@ -84,6 +89,7 @@ class Switch extends React.Component {
         disabled: false,
         defaultChecked: false,
         isPreview: false,
+        loading: false,
         readOnly: false,
         onChange: () => {},
         locale: zhCN.Switch,
@@ -136,6 +142,7 @@ class Switch extends React.Component {
             disabled,
             readOnly,
             size,
+            loading,
             checkedChildren,
             unCheckedChildren,
             rtl,
@@ -155,6 +162,7 @@ class Switch extends React.Component {
 
         const classes = classNames({
             [`${prefix}switch`]: true,
+            [`${prefix}switch-loading`]: loading,
             [`${prefix}switch-${status}`]: true,
             [`${prefix}switch-${_size}`]: true,
             [className]: className,
@@ -205,6 +213,7 @@ class Switch extends React.Component {
                 {...attrs}
                 aria-checked={checked}
             >
+                <div className={`${prefix}switch-btn`}>{loading && <Icon type="loading" size={size} />}</div>
                 <div className={`${prefix}switch-children`}>{children}</div>
             </div>
         );

--- a/src/switch/index.jsx
+++ b/src/switch/index.jsx
@@ -213,7 +213,9 @@ class Switch extends React.Component {
                 {...attrs}
                 aria-checked={checked}
             >
-                <div className={`${prefix}switch-btn`}>{loading && <Icon type="loading" size={size} />}</div>
+                <div className={`${prefix}switch-btn`}>
+                    {loading && <Icon type="loading" className={`${prefix}switch-inner-icon`} />}
+                </div>
                 <div className={`${prefix}switch-children`}>{children}</div>
             </div>
         );

--- a/src/switch/main.scss
+++ b/src/switch/main.scss
@@ -38,11 +38,11 @@
         @include bounding($switch-size-m-width, $switch-size-m-trigger, #{$switch-border-width-container}, $switch-border-width-trigger, $switch-size-m-radius-container, $switch-size-m-radius-trigger);
 
         &.#{$css-prefix}switch.#{$css-prefix}switch-on > .#{$css-prefix}switch-children {
-            margin: 0 calc(#{$switch-size-m-trigger} + #{$switch-size-m-trigger-padding}) 0 $switch-size-m-trigger-padding;
+            margin: 0 calc(#{$switch-size-m-trigger} + #{$switch-size-m-trigger-padding-r}) 0 $switch-size-m-trigger-padding-l;
         }
 
         &.#{$css-prefix}switch.#{$css-prefix}switch-off > .#{$css-prefix}switch-children {
-            margin: 0 $switch-size-m-trigger-padding 0 calc(#{$switch-size-m-trigger} + #{$switch-size-m-trigger-padding});
+            margin: 0 $switch-size-m-trigger-padding-r 0 calc(#{$switch-size-m-trigger} + #{$switch-size-m-trigger-padding-l});
         }
 
         &.#{$css-prefix}switch-loading .#{$css-prefix}icon-loading {
@@ -57,11 +57,11 @@
         @include bounding($switch-size-s-width, $switch-size-s-trigger, #{$switch-border-width-container}, $switch-border-width-trigger, $switch-size-s-radius-container, $switch-size-s-radius-trigger);
 
         &.#{$css-prefix}switch.#{$css-prefix}switch-on > .#{$css-prefix}switch-children {
-            margin: 0 calc(#{$switch-size-s-trigger} + #{$switch-size-s-trigger-padding}) 0 $switch-size-s-trigger-padding;
+            margin: 0 calc(#{$switch-size-s-trigger} + #{$switch-size-s-trigger-padding-r}) 0 $switch-size-s-trigger-padding-l;
         }
 
         &.#{$css-prefix}switch.#{$css-prefix}switch-off > .#{$css-prefix}switch-children {
-            margin: 0 $switch-size-s-trigger-padding 0 calc(#{$switch-size-s-trigger} + #{$switch-size-s-trigger-padding});
+            margin: 0 $switch-size-s-trigger-padding-r 0 calc(#{$switch-size-s-trigger} + #{$switch-size-s-trigger-padding-l});
         }
         &.#{$css-prefix}switch-loading .#{$css-prefix}icon-loading {
             @include icon-size($switch-size-s-inner-icon);

--- a/src/switch/main.scss
+++ b/src/switch/main.scss
@@ -10,54 +10,88 @@
     outline: none;
     text-align: left;
     transition: all $motion-duration-immediately $motion-linear;
-    overflow: hidden;
     cursor: pointer;
+    vertical-align: middle;
 
-    &:after {
-        content: " ";
+    &-btn {
         transition: all $motion-duration-immediately $motion-linear;
         transform-origin: left center;
+    }
+    &:after {
+        content: "";
+    }
+
+    &-loading {
+        pointer-events: none;
+        .#{$css-prefix}icon-loading {
+            color: $color-brand1-6;
+            text-align: center;
+            transform: translate(calc(0px - #{$switch-border-width-trigger}), calc(0px - #{$switch-border-width-trigger} - #{$switch-border-width-container}));
+        }
     }
 
     &-medium {
         @include bounding($switch-size-m-width, $switch-size-m-trigger, #{$switch-border-width-container}, $switch-border-width-trigger, $switch-size-m-radius-container, $switch-size-m-radius-trigger);
+
+        &.#{$css-prefix}switch.#{$css-prefix}switch-on > .#{$css-prefix}switch-children {
+            margin: 0 calc(#{$switch-size-m-trigger} + #{$switch-size-m-trigger-padding}) 0 $switch-size-m-trigger-padding;
+        }
+
+        &.#{$css-prefix}switch.#{$css-prefix}switch-off > .#{$css-prefix}switch-children {
+            margin: 0 $switch-size-m-trigger-padding 0 calc(#{$switch-size-m-trigger} + #{$switch-size-m-trigger-padding});
+        }
+
+        &.#{$css-prefix}switch-loading .#{$css-prefix}icon-loading {
+            width: $switch-size-m-trigger;
+            height: $switch-size-m-trigger;
+            line-height: $switch-size-m-trigger;
+        }
     }
 
     &-small {
         @include bounding($switch-size-s-width, $switch-size-s-trigger, #{$switch-border-width-container}, $switch-border-width-trigger, $switch-size-s-radius-container, $switch-size-s-radius-trigger);
+
+        &.#{$css-prefix}switch.#{$css-prefix}switch-on > .#{$css-prefix}switch-children {
+            margin: 0 calc(#{$switch-size-s-trigger} + #{$switch-size-s-trigger-padding}) 0 $switch-size-s-trigger-padding;
+        }
+
+        &.#{$css-prefix}switch.#{$css-prefix}switch-off > .#{$css-prefix}switch-children {
+            margin: 0 $switch-size-s-trigger-padding 0 calc(#{$switch-size-s-trigger} + #{$switch-size-s-trigger-padding});
+        }
+        &.#{$css-prefix}switch-loading .#{$css-prefix}icon-loading {
+            width: $switch-size-s-trigger;
+            height: $switch-size-s-trigger;
+            line-height: $switch-size-s-trigger;
+        }
     }
 
     &-on {
         background-color: $switch-normal-on-bg-color;
-        &:after {
+        .#{$css-prefix}switch-btn {
             box-shadow: $switch-on-shadow;
             background-color: $switch-normal-on-trigger-bg-color;
             border-color: $switch-handle-on-border-color;
         }
+
         > .#{$css-prefix}switch-children {
-            left: calc(#{$switch-text-on-left} + #{$switch-border-width-container} * 2);
             color: $switch-normal-on-color-font;
         }
 
         &:focus,
+        &.hover,
         &:hover {
             background-color: $switch-hover-on-bg-color;
-            &:after {
+            .#{$css-prefix}switch-btn {
                 background-color: $switch-hover-on-trigger-bg-color;
             }
         }
     }
 
-    &-on#{&}-small {
-        > .#{$css-prefix}switch-children {
-            left: calc(#{$switch-size-s-text-on-left} + #{$switch-border-width-container} * 2);
-        }
-    }
     &-on[disabled] {
         background-color: $switch-disabled-on-bg-color;
         cursor: not-allowed;
 
-        &:after {
+        .#{$css-prefix}switch-btn {
             right: 0;
             box-shadow: $switch-on-shadow;
             background-color: $switch-disabled-on-trigger-bg-color;
@@ -73,42 +107,42 @@
         border-color: $switch-normal-off-border-color;
 
         &:focus,
+        &.hover,
         &:hover {
             background-color: $switch-hover-off-bg-color;
             border-color: $switch-hover-off-border-color;
         }
 
-        &:after {
+        .#{$css-prefix}switch-btn {
             left: 0;
             transform: translateX(0);
             box-shadow: $switch-on-shadow;
             background-color: $switch-normal-off-trigger-bg-color;
             border-color: $switch-handle-off-border-color;
-            &:focus,
-            &:hover {
+        }
+        &:focus,
+        &.hover,
+        &:hover {
+            .#{$css-prefix}switch-btn {
                 background-color: $switch-hover-off-trigger-bg-color;
             }
         }
+
         > .#{$css-prefix}switch-children {
-            right: calc(#{$switch-text-off-right} + #{$switch-border-width-container} * 2);
             color: $switch-normal-off-color-font;
         }
     }
     &-off[disabled] {
         background-color: $switch-disabled-off-bg-color;
         cursor: not-allowed;
-        &:after {
+
+        .#{$css-prefix}switch-btn {
             box-shadow: $switch-off-shadow;
             background-color: $switch-disabled-off-trigger-bg-color;
             border-color: $switch-handle-disabled-border-color;
         }
         > .#{$css-prefix}switch-children {
             color: $switch-disabled-off-color-font;
-        }
-    }
-    &-off#{&}-small {
-        > .#{$css-prefix}switch-children {
-            right: calc(#{$switch-size-s-text-off-right} + #{$switch-border-width-container});
         }
     }
 }

--- a/src/switch/main.scss
+++ b/src/switch/main.scss
@@ -26,7 +26,11 @@
         .#{$css-prefix}icon-loading {
             color: $color-brand1-6;
             text-align: center;
-            transform: translate(calc(0px - #{$switch-border-width-trigger}), calc(0px - #{$switch-border-width-trigger} - #{$switch-border-width-container}));
+            transform: translate(calc(0px - #{$switch-border-width-trigger}), calc(0px - #{$switch-border-width-trigger}));
+
+            &.#{$css-prefix}switch-inner-icon:before {
+                vertical-align: top;
+            }
         }
     }
 
@@ -42,9 +46,10 @@
         }
 
         &.#{$css-prefix}switch-loading .#{$css-prefix}icon-loading {
-            width: $switch-size-m-trigger;
-            height: $switch-size-m-trigger;
+            @include icon-size($switch-size-m-inner-icon);
             line-height: $switch-size-m-trigger;
+            height: $switch-size-m-trigger;
+            width: $switch-size-m-trigger;
         }
     }
 
@@ -59,15 +64,17 @@
             margin: 0 $switch-size-s-trigger-padding 0 calc(#{$switch-size-s-trigger} + #{$switch-size-s-trigger-padding});
         }
         &.#{$css-prefix}switch-loading .#{$css-prefix}icon-loading {
-            width: $switch-size-s-trigger;
-            height: $switch-size-s-trigger;
+            @include icon-size($switch-size-s-inner-icon);
             line-height: $switch-size-s-trigger;
+            height: $switch-size-s-trigger;
+            width: $switch-size-s-trigger;
         }
     }
 
     &-on {
         background-color: $switch-normal-on-bg-color;
         .#{$css-prefix}switch-btn {
+            transform: translateX(-100%);
             box-shadow: $switch-on-shadow;
             background-color: $switch-normal-on-trigger-bg-color;
             border-color: $switch-handle-on-border-color;
@@ -115,7 +122,6 @@
 
         .#{$css-prefix}switch-btn {
             left: 0;
-            transform: translateX(0);
             box-shadow: $switch-on-shadow;
             background-color: $switch-normal-off-trigger-bg-color;
             border-color: $switch-handle-off-border-color;

--- a/src/switch/rtl.scss
+++ b/src/switch/rtl.scss
@@ -23,8 +23,6 @@
 
     &-on[dir="rtl"] {
         > .#{$css-prefix}switch-children {
-            right: calc(#{$switch-text-on-left} + #{$switch-border-width-container} * 2);
-            left: auto;
             color: $switch-normal-on-color-font;
         }
     }
@@ -37,13 +35,6 @@
         }
     }
 
-    &-on#{&}-small[dir="rtl"] {
-        > .#{$css-prefix}switch-children {
-            right: calc(#{$switch-size-s-text-on-left} + #{$switch-border-width-container} * 2);
-            left: auto;
-        }
-    }
-
     &-off[dir="rtl"] {
         &:after {
             right: 0;
@@ -51,14 +42,12 @@
             box-shadow: $switch-rtl-on-shadow;
         }
         > .#{$css-prefix}switch-children {
-            left: calc(#{$switch-text-off-right} + #{$switch-border-width-container} * 2);
             right: auto;
         }
     }
 
     &-off#{&}-small[dir="rtl"] {
         > .#{$css-prefix}switch-children {
-            left: calc(#{$switch-size-s-text-off-right} + #{$switch-border-width-container});
             right: auto;
         }
     }

--- a/src/switch/scss/mixin.scss
+++ b/src/switch/scss/mixin.scss
@@ -24,7 +24,7 @@
         border: $border-width-trigger solid transparent;
         position: absolute;
         left: 100%;
-        transform: translateX(-100%);
+        // transform: translateX(-100%);
         width: $trigger-size;
         height: $trigger-size;
         border-radius: $trigger-radius;

--- a/src/switch/scss/mixin.scss
+++ b/src/switch/scss/mixin.scss
@@ -13,14 +13,16 @@
     position: relative;
     display: inline-block;
     border: $border-width-container solid transparent;
-    width: $width;
+    min-width: $width;
     height: calc(#{$trigger-size} + #{$border-width-container} * 2);
     border-radius: $container-radius;
 
     &:after {
+        content: '';
+    }
+    > .#{$css-prefix}switch-btn {
         border: $border-width-trigger solid transparent;
         position: absolute;
-        // left: $width - $border-width-container * 2 - $trigger-size;
         left: 100%;
         transform: translateX(-100%);
         width: $trigger-size;
@@ -30,8 +32,6 @@
     }
     > .#{$css-prefix}switch-children {
         font-size: $font-size-body-1;
-        position: absolute;
-        // width: $trigger-size;
         height: $trigger-size;
         line-height: $trigger-size;
     }

--- a/src/switch/scss/variable.scss
+++ b/src/switch/scss/variable.scss
@@ -32,9 +32,13 @@ $switch-size-m-radius-trigger: $corner-3 !default;
 /// @namespace size/handle
 $switch-size-m-inner-icon: $s-4 !default;
 
-/// padding(l, r)
+/// padding(l)
 /// @namespace size/content
-$switch-size-m-trigger-padding: $s-2 !default;
+$switch-size-m-trigger-padding-l: $s-2 !default;
+
+/// padding(r)
+/// @namespace size/content
+$switch-size-m-trigger-padding-r: $s-2 !default;
 
 // Small
 // ----------------------------------------
@@ -57,9 +61,12 @@ $switch-size-s-radius-trigger: $corner-3 !default;
 /// @namespace size/handle
 $switch-size-s-inner-icon: $s-3 !default;
 
-/// padding(l, r)
+/// padding(l)
 /// @namespace size/content
-$switch-size-s-trigger-padding: $s-2 !default;
+$switch-size-s-trigger-padding-l: $s-2 !default;
+/// padding(r)
+/// @namespace size/content
+$switch-size-s-trigger-padding-r: $s-2 !default;
 
 /// border
 /// @namespace size/bounding

--- a/src/switch/scss/variable.scss
+++ b/src/switch/scss/variable.scss
@@ -28,6 +28,10 @@ $switch-size-m-trigger: $s-6 !default;
 /// @namespace size/handle
 $switch-size-m-radius-trigger: $corner-3 !default;
 
+/// icon size
+/// @namespace size/handle
+$switch-size-m-inner-icon: $s-4 !default;
+
 /// padding(l, r)
 /// @namespace size/content
 $switch-size-m-trigger-padding: $s-2 !default;
@@ -48,6 +52,10 @@ $switch-size-s-trigger: $s-5 !default;
 /// radius
 /// @namespace size/handle
 $switch-size-s-radius-trigger: $corner-3 !default;
+
+/// icon size
+/// @namespace size/handle
+$switch-size-s-inner-icon: $s-3 !default;
 
 /// padding(l, r)
 /// @namespace size/content

--- a/src/switch/scss/variable.scss
+++ b/src/switch/scss/variable.scss
@@ -14,7 +14,7 @@
 
 // Medium
 // ----------------------------------------
-/// width
+/// min-width
 /// @namespace size/bounding
 $switch-size-m-width: $s-14 !default;
 /// radius
@@ -28,9 +28,13 @@ $switch-size-m-trigger: $s-6 !default;
 /// @namespace size/handle
 $switch-size-m-radius-trigger: $corner-3 !default;
 
+/// padding(l, r)
+/// @namespace size/content
+$switch-size-m-trigger-padding: $s-2 !default;
+
 // Small
 // ----------------------------------------
-/// width
+/// min-width
 /// @namespace size/bounding
 $switch-size-s-width: $s-11 !default;
 
@@ -45,24 +49,18 @@ $switch-size-s-trigger: $s-5 !default;
 /// @namespace size/handle
 $switch-size-s-radius-trigger: $corner-3 !default;
 
+/// padding(l, r)
+/// @namespace size/content
+$switch-size-s-trigger-padding: $s-2 !default;
+
 /// border
 /// @namespace size/bounding
-$switch-border-width-container: $line-1 !default;
+$switch-border-width-container: $line-2 !default;
 
-/// on(l)
-/// @namespace size/content
+// 去掉这四个配置项，用 $switch-size-s-trigger-padding $switch-size-m-trigger-padding
 $switch-text-on-left: $s-2 !default;
-
-/// on-small(l)
-/// @namespace size/content
 $switch-size-s-text-on-left: $s-1 !default;
-
-/// off(r)
-/// @namespace size/content
 $switch-text-off-right: $s-2 !default;
-
-/// off-small(r)
-/// @namespace size/content
 $switch-size-s-text-off-right: $s-1 !default;
 
 /// border
@@ -133,18 +131,17 @@ $switch-on-shadow: $shadow-1 !default;
 /// background
 /// @level off
 /// @namespace statement/normal/bounding
-$switch-normal-off-bg-color: $color-white !default;
+$switch-normal-off-bg-color: $color-fill1-3 !default;
 /// background
 /// @level off
 /// @state hover
 /// @namespace statement/hover/bounding
-$switch-hover-off-bg-color: $color-fill1-2 !default;
+$switch-hover-off-bg-color: $color-fill1-3 !default;
 /// background
 /// @level off
 /// @state disabled
 /// @namespace statement/disabled/bounding
-$switch-disabled-off-bg-color: $color-fill1-1 !default;
-
+$switch-disabled-off-bg-color: $color-fill1-3 !default;
 /// background
 /// @level off
 /// @namespace statement/normal/handle
@@ -162,7 +159,7 @@ $switch-disabled-off-trigger-bg-color: $color-fill1-1 !default;
 /// border color
 /// @state disabled
 /// @namespace statement/disabled/handle
-$switch-handle-disabled-border-color: $color-line1-1 !default;
+$switch-handle-disabled-border-color: transparent !default;
 /// text
 /// @level on
 /// @namespace statement/normal/content
@@ -181,12 +178,12 @@ $switch-handle-off-border-color: $color-transparent !default;
 /// border
 /// @level off
 /// @namespace statement/normal/bounding
-$switch-normal-off-border-color: $color-line1-3 !default;
+$switch-normal-off-border-color: $color-fill1-3 !default;
 /// border
 /// @level off
 /// @state hover
 /// @namespace statement/hover/bounding
-$switch-hover-off-border-color: $color-line1-3 !default;
+$switch-hover-off-border-color: $color-fill1-3 !default;
 /// shadow
 /// @level off
 /// @namespace statement/normal/bounding

--- a/src/switch/style.js
+++ b/src/switch/style.js
@@ -1,1 +1,2 @@
+import '../icon/style.js';
 import './main.scss';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10049465/116503904-c02db780-a8e9-11eb-9eb0-060b2a0e014d.png)

可能的变化：
1. switch由原来的固定宽（width: $s-4）,改为min-witdh，最小宽
2. switch现在宽度随着内容变化，内容长switch就长