### PR TITLE
feat(Breadcrumb): add `showHiddenItems` prop

### DIFF
--- a/docs/breadcrumb/demo/custom-item.md
+++ b/docs/breadcrumb/demo/custom-item.md
@@ -1,12 +1,12 @@
 # 自定义节点
 
-- order: 4
+- order: 5
 
 可以自定义面包屑的节点，比如 react 路由。
 
 :::lang=en-us
 # Set Separator
-- order: 4
+- order: 5
 You can put your content in BreadCrumb.Item, like ReactRouter.
 :::
 ---

--- a/docs/breadcrumb/demo/separator.md
+++ b/docs/breadcrumb/demo/separator.md
@@ -1,12 +1,12 @@
 # 设置分隔符
 
-- order: 3
+- order: 4
 
 也可以设置不同的分隔符。
 
 :::lang=en-us
 # Set Separator
-- order: 3
+- order: 4
 You can also set specific separators.
 :::
 ---

--- a/docs/breadcrumb/demo/show-hidden-more.md
+++ b/docs/breadcrumb/demo/show-hidden-more.md
@@ -1,0 +1,27 @@
+# 省略号可点击展开
+
+- order: 3
+
+点击省略号展示被隐藏的项。
+
+:::lang=en-us
+# Show Omission
+- order: 3
+Hidden items will be displayed when ellipses clicked.
+:::
+---
+
+````jsx
+import { Breadcrumb, Dropdown, Menu } from '@alifd/next';
+
+ReactDOM.render(
+    <Breadcrumb maxNode={5} showHiddenItems>
+        <Breadcrumb.Item link="javascript:void(0);">Home 1</Breadcrumb.Item>
+        <Breadcrumb.Item link="javascript:void(0);">Whatever 2</Breadcrumb.Item>
+        <Breadcrumb.Item link="javascript:void(0);">All Categories 3</Breadcrumb.Item>
+        <Breadcrumb.Item link="javascript:void(0);">Women’s Clothing 4</Breadcrumb.Item>
+        <Breadcrumb.Item link="javascript:void(0);">Blouses & Shirts 5</Breadcrumb.Item>
+        <Breadcrumb.Item>T-shirts 6</Breadcrumb.Item>
+    </Breadcrumb>,
+    mountNode);
+````

--- a/docs/breadcrumb/demo/show-hidden-more.md
+++ b/docs/breadcrumb/demo/show-hidden-more.md
@@ -12,7 +12,7 @@ Hidden items will be displayed when ellipses clicked.
 ---
 
 ````jsx
-import { Breadcrumb, Dropdown, Menu } from '@alifd/next';
+import { Breadcrumb } from '@alifd/next';
 
 ReactDOM.render(
     <Breadcrumb maxNode={5} showHiddenItems>

--- a/docs/breadcrumb/index.md
+++ b/docs/breadcrumb/index.md
@@ -18,13 +18,16 @@
 
 ### Breadcrumb
 
-| 参数              | 说明                                          | 类型               | 默认值   |
-| --------------- | ------------------------------------------- | ---------------- | ----- |
-| children        | 面包屑子节点，需传入 Breadcrumb.Item                  | custom           | -     |
-| maxNode         | 面包屑最多显示个数，超出部分会被隐藏, 设置为 auto 会自动根据父元素的宽度适配。 | Number/Enum      | 100   |
-| showHiddenItems | 当超过的项被隐藏时，是否可通过点击省略号展示菜单（包含被隐藏的项）           | Boolean          | false |
-| separator       | 分隔符，可以是文本或 Icon                             | ReactNode/String | -     |
-| component       | 设置标签类型                                      | String/Function  | 'nav' |
+| 参数              | 说明                                          | 类型               | 默认值   | 版本支持 |
+| --------------- | ------------------------------------------- | ---------------- | ----- | ---- |
+| children        | 面包屑子节点，需传入 Breadcrumb.Item                  | custom           | -     |      |
+| maxNode         | 面包屑最多显示个数，超出部分会被隐藏, 设置为 auto 会自动根据父元素的宽度适配。 | Number/Enum      | 100   |      |
+| showHiddenItems | 当超过的项被隐藏时，是否可通过点击省略号展示菜单（包含被隐藏的项）           | Boolean          | false | 1.23 |
+| popupContainer  | 弹层挂载的容器节点（在showHiddenItems为true时才有意义）       | any              | -     | 1.23 |
+| followTrigger   | 是否跟随trigger滚动（在showHiddenItems为true时才有意义）   | Boolean          | -     | 1.23 |
+| popupProps      | 添加到弹层上的属性（在showHiddenItems为true时才有意义）       | Object           | -     | 1.23 |
+| separator       | 分隔符，可以是文本或 Icon                             | ReactNode/String | -     |      |
+| component       | 设置标签类型                                      | String/Function  | 'nav' |      |
 
 ### Breadcrumb.Item
 

--- a/docs/breadcrumb/index.md
+++ b/docs/breadcrumb/index.md
@@ -18,12 +18,13 @@
 
 ### Breadcrumb
 
-| 参数        | 说明                                          | 类型               | 默认值   |
-| --------- | ------------------------------------------- | ---------------- | ----- |
-| children  | 面包屑子节点，需传入 Breadcrumb.Item                  | custom           | -     |
-| maxNode   | 面包屑最多显示个数，超出部分会被隐藏, 设置为 auto 会自动根据父元素的宽度适配。 | Number/Enum      | 100   |
-| separator | 分隔符，可以是文本或 Icon                             | ReactNode/String | -     |
-| component | 设置标签类型                                      | String/Function  | 'nav' |
+| 参数              | 说明                                          | 类型               | 默认值   |
+| --------------- | ------------------------------------------- | ---------------- | ----- |
+| children        | 面包屑子节点，需传入 Breadcrumb.Item                  | custom           | -     |
+| maxNode         | 面包屑最多显示个数，超出部分会被隐藏, 设置为 auto 会自动根据父元素的宽度适配。 | Number/Enum      | 100   |
+| showHiddenItems | 当超过的项被隐藏时，是否可通过点击省略号展示菜单（包含被隐藏的项）           | Boolean          | false |
+| separator       | 分隔符，可以是文本或 Icon                             | ReactNode/String | -     |
+| component       | 设置标签类型                                      | String/Function  | 'nav' |
 
 ### Breadcrumb.Item
 

--- a/src/breadcrumb/index.jsx
+++ b/src/breadcrumb/index.jsx
@@ -157,7 +157,7 @@ class Breadcrumb extends Component {
             }
         });
 
-        const { followTrigger, popupContainer, popupProps } = this.props;
+        const { prefix, followTrigger, popupContainer, popupProps } = this.props;
 
         return (
             <Dropdown

--- a/src/breadcrumb/index.jsx
+++ b/src/breadcrumb/index.jsx
@@ -44,6 +44,7 @@ class Breadcrumb extends Component {
         maxNode: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]),
         /**
          * 当超过的项被隐藏时，是否可通过点击省略号展示菜单（包含被隐藏的项）
+         * @version 1.23
          */
         showHiddenItems: PropTypes.bool,
         /**

--- a/src/breadcrumb/index.jsx
+++ b/src/breadcrumb/index.jsx
@@ -112,7 +112,7 @@ class Breadcrumb extends Component {
     }
 
     computeMaxNode = () => {
-        // 计算最大node节点，无法获取到 ... 节点的宽度，目前会有 nodeWidth - ellipsisNodeWidth 的误差
+        // 计算最大node节点，无法获取到 ... 节点的宽度，目前会有 nodeWidth - ellipsisNodeWidth 的误差
         if (this.props.maxNode !== 'auto' || !this.breadcrumbEl) return;
         const scrollWidth = this.breadcrumbEl.scrollWidth;
         const rect = this.breadcrumbEl.getBoundingClientRect();
@@ -162,7 +162,6 @@ class Breadcrumb extends Component {
         return (
             <Dropdown
                 trigger={<span>...</span>}
-                triggerType={'click'}
                 {...popupProps}
                 container={popupContainer}
                 followTrigger={followTrigger}

--- a/src/breadcrumb/index.jsx
+++ b/src/breadcrumb/index.jsx
@@ -48,6 +48,21 @@ class Breadcrumb extends Component {
          */
         showHiddenItems: PropTypes.bool,
         /**
+         * 弹层挂载的容器节点（在showHiddenItems为true时才有意义）
+         * @version 1.23
+         */
+        popupContainer: PropTypes.any,
+        /**
+         * 是否跟随trigger滚动（在showHiddenItems为true时才有意义）
+         * @version 1.23
+         */
+        followTrigger: PropTypes.bool,
+        /**
+         * 添加到弹层上的属性（在showHiddenItems为true时才有意义）
+         * @version 1.23
+         */
+        popupProps: PropTypes.object,
+        /**
          * 分隔符，可以是文本或 Icon
          */
         separator: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
@@ -142,8 +157,16 @@ class Breadcrumb extends Component {
             }
         });
 
+        const { followTrigger, popupContainer, popupProps } = this.props;
+
         return (
-            <Dropdown trigger={<span>...</span>} triggerType={'click'}>
+            <Dropdown
+                trigger={<span>...</span>}
+                triggerType={'click'}
+                {...popupProps}
+                container={popupContainer}
+                followTrigger={followTrigger}
+            >
                 <Menu>{hiddenItems}</Menu>
             </Dropdown>
         );

--- a/src/breadcrumb/index.jsx
+++ b/src/breadcrumb/index.jsx
@@ -167,7 +167,9 @@ class Breadcrumb extends Component {
                 container={popupContainer}
                 followTrigger={followTrigger}
             >
-                <Menu>{hiddenItems}</Menu>
+                <div className={`${prefix}breadcrumb-dropdown-wrapper`}>
+                    <Menu>{hiddenItems}</Menu>
+                </div>
             </Dropdown>
         );
     }

--- a/src/breadcrumb/main.scss
+++ b/src/breadcrumb/main.scss
@@ -35,5 +35,9 @@
         &-icon-sep::before {
             content: $breadcrumb-icon-sep-content;
         }
+
+        &-dropdown-wrapper {
+            padding: $s-1 0;
+        }
     }
 }

--- a/src/breadcrumb/scss/mixin.scss
+++ b/src/breadcrumb/scss/mixin.scss
@@ -107,6 +107,11 @@
         cursor: default;
     }
 
+    .#{$css-prefix}breadcrumb-text-ellipsis-clickable {
+        color: $ellipsisTextColor;
+        cursor: pointer;
+    }
+
     .#{$css-prefix}breadcrumb-separator {
         color: $iconColor;
     }

--- a/src/breadcrumb/style.js
+++ b/src/breadcrumb/style.js
@@ -1,2 +1,4 @@
 import '../icon/style.js';
+import '../menu/style.js';
+import '../dropdown/style.js';
 import './main.scss';

--- a/test/breadcrumb/index-spec.js
+++ b/test/breadcrumb/index-spec.js
@@ -104,6 +104,31 @@ describe('Breadcrumb', () => {
         assert(ellipsisItem.textContent === '...');
     });
 
+    it('should show hidden items menu when ellipsis clicked if showHiddenItems set true', () => {
+        ReactDOM.render(
+            <Breadcrumb maxNode={5} showHiddenItems>
+                <Item>Home 1</Item>
+                <Item>Whatever 2</Item>
+                <Item>All Categories 3</Item>
+                <Item>Women’s Clothing 4</Item>
+                <Item>Blouses & Shirts 5</Item>
+                <Item>T-shirts 6</Item>
+            </Breadcrumb>
+        , mountNode);
+        const ellipsisItem = mountNode.querySelectorAll('.next-breadcrumb-text-ellipsis-clickable span')[0];
+        assert.equal(ellipsisItem.textContent, '...');
+
+        ellipsisItem.click();
+        const menuItems = document.body.querySelectorAll('.next-menu-item');
+        assert.equal(menuItems.length, 2);
+
+        const menuItem1 = menuItems[0].querySelector('.next-menu-item-text');
+        assert.equal(menuItem1.textContent, 'Whatever 2');
+
+        const menuItem2 = menuItems[1].querySelector('.next-menu-item-text');
+        assert.equal(menuItem2.textContent, 'All Categories 3');
+    });
+
     it('should not render the separator of the last item', () => {
         const wrapper = mount(
             <Breadcrumb>

--- a/test/breadcrumb/index-spec.js
+++ b/test/breadcrumb/index-spec.js
@@ -106,7 +106,7 @@ describe('Breadcrumb', () => {
 
     it('should show hidden items menu when ellipsis clicked if showHiddenItems set true', () => {
         ReactDOM.render(
-            <Breadcrumb maxNode={5} showHiddenItems>
+            <Breadcrumb maxNode={5} showHiddenItems popupProps={{triggerType: 'click'}}>
                 <Item>Home 1</Item>
                 <Item>Whatever 2</Item>
                 <Item>All Categories 3</Item>

--- a/types/breadcrumb/index.d.ts
+++ b/types/breadcrumb/index.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="react" />
 
 import * as React from 'react';
+import { PopupProps } from '../overlay';
 
 export interface ItemProps extends React.HTMLAttributes<HTMLElement> {
     /**
@@ -35,6 +36,22 @@ export interface BreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
      * 设置标签类型
      */
     component?: string | (() => void);
+    /**
+     * 当超过的项被隐藏时，是否可通过点击省略号展示菜单（包含被隐藏的项）
+     */
+     showHiddenItems?: boolean;
+     /**
+      * 弹层挂载的容器节点（在showHiddenItems为true时才有意义）
+      */
+     popupContainer?: any;
+     /**
+      * 是否跟随trigger滚动（在showHiddenItems为true时才有意义）
+      */
+     followTrigger?: boolean;
+     /**
+      * 添加到弹层上的属性（在showHiddenItems为true时才有意义）
+      */
+     popupProps?: PopupProps;
 }
 
 export default class Breadcrumb extends React.Component<BreadcrumbProps, any> {


### PR DESCRIPTION
https://github.com/alibaba-fusion/next/issues/2968

### 改动点
- 增加`showHiddenItems`属性表示*点击省略号是否展示被隐藏的项*，默认`false`（版本兼容性）。
- 如设置`showHiddenItems: true`，则省略号的css class变更为`next-breadcrumb-text-ellipsis-clickable`。
- `Breadcrumb`组件增加对`Dropdown`和`Menu`的依赖。
- 增加相关demo。