### PR TITLE
fix(ConfigProvider): fix moment import

### DIFF
--- a/src/config-provider/index.jsx
+++ b/src/config-provider/index.jsx
@@ -23,7 +23,7 @@ const setMomentLocale = locale => {
     let moment;
     try {
         moment = require('moment');
-        if (moment.default && moment.default.isMoment) moment = moment.default;
+        if (moment && moment.default && moment.default.isMoment) moment = moment.default;
     } catch (e) {
         // ignore
     }

--- a/src/config-provider/index.jsx
+++ b/src/config-provider/index.jsx
@@ -23,6 +23,7 @@ const setMomentLocale = locale => {
     let moment;
     try {
         moment = require('moment');
+        if (moment.default && moment.default.isMoment) moment = moment.default;
     } catch (e) {
         // ignore
     }


### PR DESCRIPTION
被esbuild打包的时候，`require('moment')`得到的是模块对象，它的default才是我们需要的moment对象。