### PR TITLE
fix(Select): should support object without value in item

### DIFF
--- a/src/select/util.js
+++ b/src/select/util.js
@@ -156,7 +156,7 @@ export function normalizeDataSource(dataSource, deep = 0, showDataSourceChildren
         }
 
         // filter off addon item
-        if (item.__isAddon) {
+        if (item && item.__isAddon) {
             return;
         }
 
@@ -169,7 +169,8 @@ export function normalizeDataSource(dataSource, deep = 0, showDataSourceChildren
             item2.children = normalizeDataSource(item.children, deep + 1);
         } else {
             const { value, label, disabled, title, ...others } = item;
-            item2.value = value;
+            // undefined 认为是没传取 index 值替代
+            item2.value = typeof value !== 'undefined' ? value : `${index}`;
             item2.label = label || `${item2.value}`;
             if ('title' in item) {
                 item2.title = title;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5189853/127621548-07190066-46dd-4e8b-8ba7-608a7a4e74c6.png)

useDetailValue 的时候 object 对象里面并没有value 的兼容性判断！