### PR TITLE
fix(Table): bug when list table with useVirtal

### DIFF
--- a/docs/table/demo/list.md
+++ b/docs/table/demo/list.md
@@ -197,7 +197,7 @@ class App extends React.Component {
         return (
             <div>
                 <p><Button onClick={this.toggleGroupSelection}>Toggle GroupHeader Selection</Button></p>
-                <Table dataSource={dataSource} rowSelection={rowSelection} cellProps={cellProps}>
+                <Table tableLayout="fixed" dataSource={dataSource} rowSelection={rowSelection} cellProps={cellProps}>
                     <Table.GroupHeader cell={groupHeaderRender} hasChildrenSelection={this.state.hasSelection}/>
                     <Table.GroupFooter cell={groupHeaderRender}/>
                     <Table.Column cell={productRender} title="Product Details" dataIndex="product"/>

--- a/src/table/virtual.jsx
+++ b/src/table/virtual.jsx
@@ -94,7 +94,7 @@ export default function virtual(BaseComponent) {
         }
 
         componentDidMount() {
-            if (this.state.hasVirtualData) {
+            if (this.state.hasVirtualData && this.bodyNode) {
                 this.lastScrollTop = this.bodyNode.scrollTop;
             }
 
@@ -168,14 +168,14 @@ export default function virtual(BaseComponent) {
         }
 
         adjustScrollTop() {
-            if (this.state.hasVirtualData) {
+            if (this.state.hasVirtualData && this.bodyNode) {
                 this.bodyNode.scrollTop =
                     (this.lastScrollTop % this.state.rowHeight) + this.state.rowHeight * this.state.scrollToRow;
             }
         }
 
         adjustSize() {
-            if (this.state.hasVirtualData) {
+            if (this.state.hasVirtualData && this.bodyNode) {
                 const body = this.bodyNode;
                 const virtualScrollNode = body.querySelector('div');
                 const { clientHeight, clientWidth } = body;

--- a/test/table/index-spec.js
+++ b/test/table/index-spec.js
@@ -708,6 +708,37 @@ describe('Table', () => {
         assert(wrapper.find('tr.next-table-row').length < 40);
     });
 
+    it('should support virtual + list table', () => {
+        timeout({
+            children: [
+                <Table.GroupHeader cell={<div>header</div>} />,
+                <Table.Column dataIndex="id" />,
+                <Table.GroupFooter cell={<div>footer</div>} />,
+            ],
+            useVirtual: true,
+            dataSource: [
+                {
+                    id: '1',
+                    name: 'test',
+                    children: [
+                        {
+                            id: '12',
+                            name: '12test',
+                        },
+                    ],
+                },
+                {
+                    id: '2',
+                    name: 'test2',
+                },
+            ],
+        }).then(() => {
+            assert(wrapper.find('tr.next-table-group-header').length === 2);
+            assert(wrapper.find('tr.next-table-group-footer').length === 2);
+            done();
+        });
+    });
+
     it('should support lock row mouseEnter mouseLeave', done => {
         wrapper.setProps({
             children: [


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10049465/128313429-266cc989-7033-4dd5-9774-6e5c3c8fd80f.png)

https://github.com/alibaba-fusion/next/commit/e2aaf44 这个commit引起的，原来判断只会有didmount时的一次，后面改到了每次更新都查看。在后续更新的时候可能存在bodyNode不存在的情况（比如ListTable没有bodynode，所以ListTable一直没有虚拟滚动的能力，这里增强处理先避免报错）