### PR TITLE
fix(Table): 过滤掉无效的透传到dom属性

### DIFF
--- a/src/table/base/cell.jsx
+++ b/src/table/base/cell.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { obj } from '../../util';
+import { obj, pickAttrs } from '../../util';
 
 export default class Cell extends React.Component {
     static propTypes = {
@@ -113,7 +113,7 @@ export default class Cell extends React.Component {
         });
 
         return (
-            <Tag {...others} className={cls} style={tagStyle} role="gridcell">
+            <Tag {...pickAttrs(others)} className={cls} style={tagStyle} role="gridcell">
                 <div
                     className={`${prefix}table-cell-wrapper`}
                     style={innerStyle}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -11,6 +11,7 @@ import * as _htmlId from './htmlId';
 import _guid from './guid';
 import _KEYCODE from './keycode';
 import _date from './date';
+import _pickAttrs from './pick-attrs';
 
 export const dom = _dom;
 export const env = _env;
@@ -25,3 +26,4 @@ export const guid = _guid;
 export const KEYCODE = _KEYCODE;
 export const htmlId = _htmlId;
 export const datejs = _date;
+export const pickAttrs = _pickAttrs;

--- a/src/util/pick-attrs.js
+++ b/src/util/pick-attrs.js
@@ -1,0 +1,42 @@
+const attributes = `accept acceptCharset accessKey action allowFullScreen allowTransparency
+alt async autoComplete autoFocus autoPlay capture cellPadding cellSpacing challenge
+charSet checked classID className colSpan cols content contentEditable contextMenu
+controls coords crossOrigin data dateTime default defer dir disabled download draggable
+encType form formAction formEncType formMethod formNoValidate formTarget frameBorder
+headers height hidden high href hrefLang htmlFor httpEquiv icon id inputMode integrity
+is keyParams keyType kind label lang list loop low manifest marginHeight marginWidth max maxLength media
+mediaGroup method min minLength multiple muted name noValidate nonce open
+optimum pattern placeholder poster preload radioGroup readOnly rel required
+reversed role rowSpan rows sandbox scope scoped scrolling seamless selected
+shape size sizes span spellCheck src srcDoc srcLang srcSet start step style
+summary tabIndex target title type useMap value width wmode wrap`
+    .replace(/\s+/g, ' ')
+    .replace(/\t|\n|\r/g, '')
+    .split(' ');
+
+const eventsName = `onCopy onCut onPaste onCompositionEnd onCompositionStart onCompositionUpdate onKeyDown
+    onKeyPress onKeyUp onFocus onBlur onChange onInput onSubmit onClick onContextMenu onDoubleClick
+    onDrag onDragEnd onDragEnter onDragExit onDragLeave onDragOver onDragStart onDrop onMouseDown
+    onMouseEnter onMouseLeave onMouseMove onMouseOut onMouseOver onMouseUp onSelect onTouchCancel
+    onTouchEnd onTouchMove onTouchStart onScroll onWheel onAbort onCanPlay onCanPlayThrough
+    onDurationChange onEmptied onEncrypted onEnded onError onLoadedData onLoadedMetadata
+    onLoadStart onPause onPlay onPlaying onProgress onRateChange onSeeked onSeeking onStalled onSuspend onTimeUpdate onVolumeChange onWaiting onLoad onError`
+    .replace(/\s+/g, ' ')
+    .replace(/\t|\n|\r/g, '')
+    .split(' ');
+
+const attrsPrefix = ['data-', 'aria-'];
+/**
+ * 过滤掉无效的透传到 DOM 属性
+ */
+export default props => {
+    const attrs = {};
+    for (const key in props) {
+        if (attributes.indexOf(key) > -1 || eventsName.indexOf(key) > -1) {
+            attrs[key] = props[key];
+        } else if (attrsPrefix.map(prefix => new RegExp(`^${prefix}`)).some(reg => key.replace(reg, '') !== key)) {
+            attrs[key] = props[key];
+        }
+    }
+    return attrs;
+};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30346283/130192303-0ec4d9f7-c1dc-4a97-83b2-2bf248bf3d4d.png)

之前 Table `columns` 中的配置项会将所有属性透传，会出现 warning，现在将这些属性过滤掉。