### PR TITLE
fix: move some props to behind others

### DIFF
--- a/src/tree-select/tree-select.jsx
+++ b/src/tree-select/tree-select.jsx
@@ -830,23 +830,23 @@ class TreeSelect extends Component {
                 label={label}
                 readOnly={readOnly}
                 ref={this.saveSelectRef}
-                mode={treeCheckable || multiple ? 'multiple' : 'single'}
                 value={data}
-                onRemove={this.handleRemove}
                 onChange={this.handleChange}
                 visible={visible}
                 onVisibleChange={this.handleVisibleChange}
                 showSearch={showSearch}
                 onSearch={this.handleSearch}
                 onSearchClear={this.handleSearchClear}
-                onKeyDown={this.handleKeyDown}
-                popupContent={this.renderPopupContent()}
                 popupContainer={popupContainer}
                 popupStyle={popupStyle}
                 popupClassName={popupClassName}
                 popupProps={popupProps}
                 followTrigger={followTrigger}
                 {...others}
+                onRemove={this.handleRemove}
+                onKeyDown={this.handleKeyDown}
+                popupContent={this.renderPopupContent()}
+                mode={treeCheckable || multiple ? 'multiple' : 'single'}
             />
         );
     }


### PR DESCRIPTION
移动tree-select一些props到others后面，防止被外界错误覆盖。

例如目前版本中，如果外界使用：

```
<TreeSelect mode={undefined} />
```

因为others在后面，会导致传到Select上面的mode属性被替代，显示不正常。

Demo：（该Demo在选择选项后，下拉框中没有显示选项）
https://riddle.alibaba-inc.com/riddles/cd2caba6

对比图：
不正常
![image](https://user-images.githubusercontent.com/5326684/133364797-87c7d6d5-85d1-4226-b0e9-833add09038d.png)
正常
![image](https://user-images.githubusercontent.com/5326684/133364823-48a1cb1d-c902-44f0-8e3e-f779fba438b0.png)
