### PR TITLE
fix(DatePicker2): use flex-basis instead width to be compiable with safari, close #3463

### DIFF
--- a/src/date-picker2/main.scss
+++ b/src/date-picker2/main.scss
@@ -96,7 +96,8 @@
 
         #{$input-prefix} {
             border: none;
-            width: 100%;
+            // use flex-basis instead width to be compiable with safari
+            flex-basis: 100%;
             height: 100%;
             input {
                 height: 100%;


### PR DESCRIPTION
close #3463