### PR TITLE
fix(upload): 修复从只读态切换到输入态时无法删除已上传的问题

### DIFF
--- a/src/upload/card.jsx
+++ b/src/upload/card.jsx
@@ -89,9 +89,16 @@ class Card extends Base {
             uploaderRef: this.uploaderRef,
         };
     }
-    /* eslint react/no-did-mount-set-state: [0] */
+
     componentDidMount() {
-        this.setState({ uploaderRef: this.uploaderRef });
+        this.updateUploaderRef(this.uploaderRef);
+    }
+
+    componentDidUpdate() {
+        const { uploaderRef } = this.state;
+        if (!uploaderRef && this.uploaderRef) {
+            this.updateUploaderRef(this.uploaderRef);
+        }
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {
@@ -123,11 +130,15 @@ class Card extends Base {
     };
 
     isUploading() {
-        return this.state.uploaderRef.isUploading();
+        return this.uploaderRef.isUploading();
     }
 
     saveRef(ref) {
         this.saveUploaderRef(ref);
+    }
+
+    updateUploaderRef(uploaderRef) {
+        this.setState({ uploaderRef });
     }
 
     render() {
@@ -189,7 +200,7 @@ class Card extends Base {
                 onPreview={onPreview}
                 itemRender={itemRender}
                 isPreview={isPreview}
-                uploader={this.state.uploaderRef}
+                uploader={this.uploaderRef}
                 reUpload={reUpload}
                 showDownload={showDownload}
                 {...othersForList}


### PR DESCRIPTION
在某些场景下，从只读态切换到输入态时，点击删除，会因为 List 的 props.uploader 不存在导致删除动作不触发。