### PR TITLE
feat(dialog): support custom padding bottom when no footer

### DIFF
--- a/src/dialog/inner.jsx
+++ b/src/dialog/inner.jsx
@@ -109,10 +109,15 @@ export default class Inner extends Component {
     }
 
     renderBody() {
-        const { prefix, children } = this.props;
+        const { prefix, children, footer } = this.props;
         if (children) {
             return (
-                <div className={`${prefix}dialog-body`} ref={this.getNode.bind(this, 'bodyNode')}>
+                <div
+                    className={cx(`${prefix}dialog-body`, {
+                        [`${prefix}dialog-body-no-footer`]: footer === false
+                    })}
+                    ref={this.getNode.bind(this, 'bodyNode')}
+                >
                     {children}
                 </div>
             );

--- a/src/dialog/main.scss
+++ b/src/dialog/main.scss
@@ -6,6 +6,8 @@
     @include box-sizing;
     position: fixed;
     z-index: 1001;
+    display: flex;
+    flex-direction: column;
     background: $dialog-bg;
     border: $dialog-border-width $dialog-border-style $dialog-border-color;
     border-radius: $dialog-corner;
@@ -28,6 +30,7 @@
         font-size: $dialog-content-font-size;
         line-height: $font-lineheight-2;
         color: $dialog-content-color;
+        flex: 1 1 auto;
     }
 
     &-body-no-footer {

--- a/src/dialog/main.scss
+++ b/src/dialog/main.scss
@@ -30,6 +30,13 @@
         color: $dialog-content-color;
     }
 
+    &-body-no-footer {
+        padding: $dialog-content-padding-top $dialog-content-padding-left-right $dialog-content-padding-bottom-no-footer $dialog-content-padding-left-right;
+        font-size: $dialog-content-font-size;
+        line-height: $font-lineheight-2;
+        color: $dialog-content-color;
+    }
+
     /* 让用户自己设置 */
     /* &.#{$css-prefix}closeable &-header, */
     /* &.#{$css-prefix}closeable &-body, { */
@@ -163,6 +170,9 @@
         }
         #{$dialog-prefix}-header + #{$dialog-prefix}-body {
             padding: $dialog-content-padding-top $dialog-content-padding-left-right $dialog-content-padding-bottom $dialog-content-padding-left-right;
+        }
+        #{$dialog-prefix}-header + #{$dialog-prefix}-body-no-footer {
+            padding: $dialog-content-padding-top $dialog-content-padding-left-right $dialog-content-padding-bottom-no-footer $dialog-content-padding-left-right;
         }
     }
 

--- a/src/dialog/scss/variable.scss
+++ b/src/dialog/scss/variable.scss
@@ -57,6 +57,9 @@ $dialog-content-padding-top: $s-5 !default;
 /// padding (b)
 /// @namespace size/content
 $dialog-content-padding-bottom: $s-5 !default;
+/// padding (b)(no-footer)
+/// @namespace size/content
+$dialog-content-padding-bottom-no-footer: $s-5 !default;
 /// padding (l, r)
 /// @namespace size/content
 $dialog-content-padding-left-right: $s-5 !default;

--- a/src/dialog/scss/variable.scss
+++ b/src/dialog/scss/variable.scss
@@ -59,7 +59,7 @@ $dialog-content-padding-top: $s-5 !default;
 $dialog-content-padding-bottom: $s-5 !default;
 /// padding (b)(no-footer)
 /// @namespace size/content
-$dialog-content-padding-bottom-no-footer: $s-5 !default;
+$dialog-content-padding-bottom-no-footer: $dialog-content-padding-bottom !default;
 /// padding (l, r)
 /// @namespace size/content
 $dialog-content-padding-left-right: $s-5 !default;


### PR DESCRIPTION
没有 footer 时，给 `.next-dialog-body` 增加一个类 `.next-dialog-body-no-footer`。这个类的 padding-bottom 会使用一个新的变量 `$dialog-content-padding-bottom-no-footer`，可供定制。默认值和原有的 `$dialog-content-padding-bottom` 一致，保证向前兼容。

Fix #3799 