### PR TITLE
refactor: use big.js instead of bignumber.js, for smaller bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@alifd/overlay": "^0.2.9",
     "@alifd/validate": "~1.2.0",
     "babel-runtime": "^6.26.0",
-    "bignumber.js": "^9.0.1",
+    "big.js": "^6.2.0",
     "classnames": "^2.2.3",
     "dayjs": "^1.9.6",
     "hoist-non-react-statics": "^3.0.0",

--- a/src/number-picker/number-picker.jsx
+++ b/src/number-picker/number-picker.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import BigNumber from 'big.js';
+import Big from 'big.js';
 import { polyfill } from 'react-lifecycles-compat';
 
 import Icon from '../icon';
@@ -236,7 +236,14 @@ class NumberPicker extends React.Component {
 
     isGreaterThan(v1, v2) {
         const { stringMode } = this.props;
-        if (stringMode) return BigNumber(v1).gt(v2);
+        if (stringMode) {
+            try {
+            return Big(v1).gt(v2);
+            } catch (e) {
+                // big.js 遇到 Infinity 和 NaN 异常回退到 Number
+                return Number(v1) > Number(v2);
+            }
+        }
         return Number(v1) > Number(v2);
     }
 
@@ -273,7 +280,7 @@ class NumberPicker extends React.Component {
             !this.withinMinMax(displayValue)
         ) {
             let valueCorrected = this.correctValue(displayValue);
-            valueCorrected = stringMode ? BigNumber(valueCorrected).toFixed(this.getPrecision()) : valueCorrected;
+            valueCorrected = stringMode ? Big(valueCorrected).toFixed(this.getPrecision()) : valueCorrected;
             if (this.state.value !== valueCorrected) {
                 this.setValue({ value: valueCorrected, e });
             }
@@ -351,7 +358,7 @@ class NumberPicker extends React.Component {
 
             // 边界订正：
             val = this.correctBoundary(val);
-            val = this.props.stringMode ? BigNumber(val).toFixed() : Number(val);
+            val = this.props.stringMode ? Big(val).toFixed() : Number(val);
         }
 
         if (isNaN(val)) val = this.state.value;
@@ -454,7 +461,7 @@ class NumberPicker extends React.Component {
             let result = (precisionFactor * val + precisionFactor * step) / precisionFactor;
             return this.hackChrome(result);
         }
-        return BigNumber(val || '0')
+        return Big(val || '0')
             .plus(step)
             .toFixed(this.getPrecision());
     }
@@ -466,7 +473,7 @@ class NumberPicker extends React.Component {
             let result = (precisionFactor * val - precisionFactor * step) / precisionFactor;
             return this.hackChrome(result);
         }
-        return BigNumber(val || '0')
+        return Big(val || '0')
             .minus(step)
             .toFixed(this.getPrecision());
     }

--- a/src/number-picker/number-picker.jsx
+++ b/src/number-picker/number-picker.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'big.js';
 import { polyfill } from 'react-lifecycles-compat';
 
 import Icon from '../icon';
@@ -236,7 +236,7 @@ class NumberPicker extends React.Component {
 
     isGreaterThan(v1, v2) {
         const { stringMode } = this.props;
-        if (stringMode) return BigNumber(v1).isGreaterThan(BigNumber(v2));
+        if (stringMode) return BigNumber(v1).gt(v2);
         return Number(v1) > Number(v2);
     }
 

--- a/test/number-picker/index-spec.js
+++ b/test/number-picker/index-spec.js
@@ -5,7 +5,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import assert from 'power-assert';
 import sinon from 'sinon';
 import NumberPicker from '../../src/number-picker/index';
-import BigNumber from "big.js";
+import Big from "big.js";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -191,18 +191,18 @@ describe('number-picker', () => {
             assert(wrapper2.find('input').prop('value') === `${Number.MIN_SAFE_INTEGER}`);
 
             wrapper.find('button').at(0).simulate('click');
-            assert(wrapper.find('input').prop('value') === BigNumber(Number.MAX_SAFE_INTEGER).plus(1).toFixed(0));
+            assert(wrapper.find('input').prop('value') === Big(Number.MAX_SAFE_INTEGER).plus(1).toFixed(0));
             wrapper.find('button').at(1).simulate('click');
-            assert(wrapper.find('input').prop('value') === BigNumber(Number.MAX_SAFE_INTEGER).toFixed(0));
+            assert(wrapper.find('input').prop('value') === Big(Number.MAX_SAFE_INTEGER).toFixed(0));
             wrapper.find('button').at(1).simulate('click');
-            assert(wrapper.find('input').prop('value') === BigNumber(Number.MAX_SAFE_INTEGER).minus(1).toFixed(0));
+            assert(wrapper.find('input').prop('value') === Big(Number.MAX_SAFE_INTEGER).minus(1).toFixed(0));
 
             wrapper2.find('button').at(0).simulate('click');
-            assert(wrapper2.find('input').prop('value') === BigNumber(Number.MIN_SAFE_INTEGER).plus(step).toFixed(precision));
+            assert(wrapper2.find('input').prop('value') === Big(Number.MIN_SAFE_INTEGER).plus(step).toFixed(precision));
             wrapper2.find('button').at(1).simulate('click');
-            assert(wrapper2.find('input').prop('value') === BigNumber(Number.MIN_SAFE_INTEGER).toFixed(precision));
+            assert(wrapper2.find('input').prop('value') === Big(Number.MIN_SAFE_INTEGER).toFixed(precision));
             wrapper2.find('button').at(1).simulate('click');
-            assert(wrapper2.find('input').prop('value') === BigNumber(Number.MIN_SAFE_INTEGER).minus(step).toFixed(precision));
+            assert(wrapper2.find('input').prop('value') === Big(Number.MIN_SAFE_INTEGER).minus(step).toFixed(precision));
         });
 
         it('should support max & min props change', () => {
@@ -245,7 +245,7 @@ describe('number-picker', () => {
             wrapper.find('input').simulate('change', { target: { value: `${Number.MAX_SAFE_INTEGER}000` } });
             assert(wrapper.find('input').prop('value') === `${Number.MAX_SAFE_INTEGER}000`);
             wrapper.find('input').simulate('blur');
-            assert(wrapper.find('input').prop('value') === BigNumber(20).toFixed(precision));
+            assert(wrapper.find('input').prop('value') === Big(20).toFixed(precision));
 
         });
 

--- a/test/number-picker/index-spec.js
+++ b/test/number-picker/index-spec.js
@@ -5,7 +5,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import assert from 'power-assert';
 import sinon from 'sinon';
 import NumberPicker from '../../src/number-picker/index';
-import BigNumber from "bignumber.js";
+import BigNumber from "big.js";
 
 Enzyme.configure({ adapter: new Adapter() });
 


### PR DESCRIPTION
big.js 大约比 bignumber.js 小一半体积，能节约几个 KB。功能上完全能够满足 fusion 组件内的需要。