### PR TITLE
fix(types/slider): pauseOnHover prop

### DIFF
--- a/types/slider/index.d.ts
+++ b/types/slider/index.d.ts
@@ -162,6 +162,11 @@ export interface SliderProps extends HTMLAttributesWeak, CommonProps {
      * 多图轮播时，点击选中后自动居中
      */
     focusOnSelect?: boolean;
+
+    /**
+     * 鼠标经过时停止播放
+     */
+    pauseOnHover?: boolean;
 }
 
 export default class Slider extends React.Component<SliderProps, any> {}


### PR DESCRIPTION
TypeScript 类型中缺少了 pauseOnHover 属性