### PR TITLE
fix(IconDocs): icon文档font_class超长省略显示

### DIFF
--- a/docs/icon/demo/type.md
+++ b/docs/icon/demo/type.md
@@ -114,6 +114,9 @@ ReactDOM.render(
     margin-top: 10px;
     text-align: center;
     font-size: 14px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .icon-list-custom-title {


### PR DESCRIPTION
解决icon的预览页中，icon的font_class值超长导致的样式错乱
![image](https://user-images.githubusercontent.com/14801448/180740334-7ab93ba9-d10a-4790-9f64-e71d260f7361.png)
