### PR TITLE
fix: make one scss variable more reusable

### DIFF
--- a/src/core/style/_corner.scss
+++ b/src/core/style/_corner.scss
@@ -45,7 +45,7 @@ $corner-semicircle: 500px !default;
 /// @semantic 直角
 /// @export
 /// @unconfigurable
-$corner-zero: 0 !default;
+$corner-zero: 0px !default;
 
 // ----------- patch ----------- //
 $corner-right-angle: $corner-zero;


### PR DESCRIPTION
A size value without unit maybe cause 'invalid property value' warnings in `calc()` css function, meanwhile this stylesheet cannot style correctly. Example below:

![image](https://user-images.githubusercontent.com/19543313/185580589-4a5ae0f4-5706-48d5-8a16-f36e03693dbf.png)

add a unit to make it more reusable ^_^.