### PR TITLE
fix(Badge): resolve Badge component position is incorrect when the child is a block element, close #3084

### DIFF
--- a/src/badge/main.scss
+++ b/src/badge/main.scss
@@ -55,7 +55,7 @@
             padding-left: $badge-size-custom-padding-lr;
             padding-right: $badge-size-custom-padding-lr;
             border-radius: $badge-size-custom-border-radius;
-            transform: translateX(-50%);
+            transform: translateX(50%);
 
             > * {
                 line-height: 1;
@@ -77,6 +77,7 @@
             z-index: 10;
             overflow: hidden;
             transform-origin: left center;
+            right: 0;
         }
 
         &-scroll-number-only {

--- a/src/badge/rtl.scss
+++ b/src/badge/rtl.scss
@@ -8,5 +8,7 @@
     .#{$css-prefix}badge-scroll-number {
         left: 0;
         transform-origin: right center;
+        right: auto;
+        transform: translateX(-50%);
     }
 }

--- a/src/badge/scss/mixin.scss
+++ b/src/badge/scss/mixin.scss
@@ -40,5 +40,5 @@
     padding: $padding;
     font-size: $fontSize;
     line-height: $lineHeight;
-    transform: translateX(-50%);
+    transform: translateX(50%);
 }


### PR DESCRIPTION
修复Badge的children为块级元素时，角标的位置异常的问题