### PR TITLE
fetchDataByPath 建议加上null判断

### DIFF
--- a/src/table/util.js
+++ b/src/table/util.js
@@ -38,7 +38,7 @@ export const fetchDataByPath = (object, path) => {
         if (val) {
             for (let colIndex = 1; colIndex < field.length; colIndex++) {
                 val = val[field[colIndex]];
-                if (typeof val === 'undefined') {
+                if (typeof val === 'undefined' || val === null) {
                     break;
                 }
             }


### PR DESCRIPTION
dataIndex 当使用a.b.c形式的快速取值时，若b为null会有错误。