### PR TITLE
fix(ConfigProvider): support using ref on function component, close #4203

### DIFF
--- a/src/config-provider/config.jsx
+++ b/src/config-provider/config.jsx
@@ -216,7 +216,7 @@ export function config(Component, options = {}) {
                     {...contextProps.defaultPropsConfig[displayName]}
                     {...newOthers}
                     {...newContextProps}
-                    ref={obj.isClassComponent(Component) ? this._getInstance : null}
+                    ref={this._getInstance}
                 />
             );
 


### PR DESCRIPTION
问题：使用通过ConfigProvider.config包裹的hooks组件时，没有办法通过ref获取到该组件的实例
解决方案：ClassComponent和hooksComponent的ref相同处理即可