### PR TITLE
fix(Menu): fix hozInLine mode popup bug when subMenu has a specified key, close #4222

### DIFF
--- a/src/menu/view/menu.jsx
+++ b/src/menu/view/menu.jsx
@@ -59,7 +59,8 @@ const addIndicators = ({ children, lastVisibleIndex, prefix, renderMore }) => {
 
         if (index > lastVisibleIndex) {
             child = React.cloneElement(child, {
-                key: child.key || `more-${index}`,
+                // 别折叠不显示的 item，不占用真实的用户传入的 key
+                key: `more-${index}`,
                 style: { display: 'none' },
                 className: `${(child && child.className) || ''} ${MENUITEM_OVERFLOWED_CLASSNAME}`,
             });


### PR DESCRIPTION
这样的改动在试了几个方案后改动最小，被折叠的 item 主要用途是计算宽度，不需要拿真实的 key导致计算时 p2n 和 k2n 被重复计算，且位置错误。