### PR TITLE
fix: remove list-style: none from reset

### DIFF
--- a/src/core/base/_reset.scss
+++ b/src/core/base/_reset.scss
@@ -6,7 +6,6 @@
 
 ul,
 ol {
-    list-style: none;
     margin: 0;
     padding: 0;
 }


### PR DESCRIPTION
reset.scss 中的 `list-style: none` 会导致页面中的常规 ol/ul 不展示项目符号，破坏阅读体验。理论上 reset 的目的是让 html 元素的样式在不同浏览器/系统中保持一致，是一种微调而不是颠覆。