### PR TITLE
fix(Balloon): the offset attribute does not take effect after the v2 version is enabled

### DIFF
--- a/src/balloon/balloon.jsx
+++ b/src/balloon/balloon.jsx
@@ -414,7 +414,6 @@ class Balloon extends React.Component {
             delete otherProps.align;
             delete otherProps.shouldUpdatePosition;
             delete otherProps.needAdjust;
-            delete otherProps.offset;
             delete otherProps.safeId;
             delete otherProps.onHover;
             delete otherProps.onPosition;


### PR DESCRIPTION
close #4378 