### PR TITLE
chore(checkbox): export dataSource item type

### DIFF
--- a/types/checkbox/index.d.ts
+++ b/types/checkbox/index.d.ts
@@ -8,12 +8,14 @@ interface HTMLAttributesWeak extends React.HTMLAttributes<HTMLElement> {
     onChange?: any;
 }
 
-export type data = {
+type data = {
     value?: string | number;
     label?: React.ReactNode;
     disabled?: boolean;
     [propName: string]: any;
 }
+
+export type CheckboxOption = data;
 
 export interface GroupProps extends HTMLAttributesWeak, CommonProps {
     /**

--- a/types/checkbox/index.d.ts
+++ b/types/checkbox/index.d.ts
@@ -8,7 +8,7 @@ interface HTMLAttributesWeak extends React.HTMLAttributes<HTMLElement> {
     onChange?: any;
 }
 
-type data = {
+export type data = {
     value?: string | number;
     label?: React.ReactNode;
     disabled?: boolean;

--- a/types/checkbox/index.d.ts
+++ b/types/checkbox/index.d.ts
@@ -15,7 +15,7 @@ type data = {
     [propName: string]: any;
 }
 
-export type CheckboxOption = data;
+export type CheckboxData = data;
 
 export interface GroupProps extends HTMLAttributesWeak, CommonProps {
     /**


### PR DESCRIPTION
导出checkBox的dataSource的子项类型，如果某个组件封装了一层checkBox，可能需要这个类型