### PR TITLE
fix(Dialog2): clear warning by ConfigProvider cross ref props with no forwardRef component, close #4246

### DIFF
--- a/src/dialog/show.jsx
+++ b/src/dialog/show.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, forwardRef, useImperativeHandle } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
@@ -6,10 +6,15 @@ import ConfigProvider from '../config-provider';
 import Message from '../message';
 import zhCN from '../locale/zh-cn';
 import dialog from './dialog';
-import dialog2 from './dialog-v2';
+import Dialog2Ins from './dialog-v2';
 
 const Dialog = ConfigProvider.config(dialog);
-const Dialog2 = ConfigProvider.config(dialog2);
+const Dialog2 = ConfigProvider.config(
+    forwardRef((props, ref) => {
+        useImperativeHandle(ref, () => undefined);
+        return <Dialog2Ins {...props} />;
+    })
+);
 
 const noop = () => {};
 const MESSAGE_TYPE = {


### PR DESCRIPTION
ConfigProvider.config默认会传递ref，这里的dialog2组件没有设置forwardRef，故而development模式下的react会报告一个warning。这个场景下，dialog2组件是不需要开放ref的，所以仅仅做一层forwardRef包裹。