### PR TITLE
fix(Box): Fix the type definition issue of Box component

### DIFF
--- a/components/box/index.d.ts
+++ b/components/box/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="react" />
 
-import { HTMLAttributes, ElementType, Component } from 'react';
+import React, { HTMLAttributes, ElementType, Component } from 'react';
 import { CommonProps } from '../util';
 
 export interface BoxProps extends HTMLAttributes<HTMLElement>, CommonProps {

--- a/components/box/index.d.ts
+++ b/components/box/index.d.ts
@@ -13,6 +13,7 @@ export interface BoxProps extends HTMLAttributes<HTMLElement>, CommonProps {
     padding?: number | Array<number>;
     justify?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | string;
     align?: 'flex-start' | 'center' | 'flex-end' | 'baseline' | 'stretch' | string;
+    component?: keyof React.JSX.IntrinsicElements;
 }
 
 export default class Box extends Component<BoxProps, any> {}

--- a/types/box/index.d.ts
+++ b/types/box/index.d.ts
@@ -13,7 +13,7 @@ export interface BoxProps extends HTMLAttributes<HTMLElement>, CommonProps {
     padding?: number | Array<number>;
     justify?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | string;
     align?: 'flex-start' | 'center' | 'flex-end' | 'baseline' | 'stretch' | string;
-    component?: string;
+    component?: keyof React.JSX.IntrinsicElements;
 }
 
 export default class Box extends Component<BoxProps, any> {}

--- a/types/box/index.d.ts
+++ b/types/box/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="react" />
 
-import { HTMLAttributes, ElementType, Component } from 'react';
+import React, { HTMLAttributes, ElementType, Component } from 'react';
 import CommonProps from '../util';
 
 export interface BoxProps extends HTMLAttributes<HTMLElement>, CommonProps {

--- a/types/box/index.d.ts
+++ b/types/box/index.d.ts
@@ -13,6 +13,7 @@ export interface BoxProps extends HTMLAttributes<HTMLElement>, CommonProps {
     padding?: number | Array<number>;
     justify?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | string;
     align?: 'flex-start' | 'center' | 'flex-end' | 'baseline' | 'stretch' | string;
+    component?: string;
 }
 
 export default class Box extends Component<BoxProps, any> {}


### PR DESCRIPTION
Fixed an issue where the `component` attribute was missing from the type definition of the Box component.