### PR TITLE
需要将dayjs排除，如果不排除，走cdn方式引入fusion的话，就无法设置dayjs的时区等等其他的操作了 所以也需要跟moment一样作为对等依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,6 +296,7 @@
   },
   "peerDependencies": {
     "@alifd/meet-react": "^2.0.0",
+    "dayjs": "^1.9.6",
     "moment": "^2.22.1",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"


### PR DESCRIPTION
需要将dayjs排除，如果不排除，走cdn方式引入fusion的话，就无法设置dayjs的时区等等其他的操作了 所以也需要跟moment一样作为对等依赖