### PR TITLE
fix(DatePicker2): Translation compliant with international standards

### DIFF
--- a/components/date-picker2/__docs__/demo/format/index.tsx
+++ b/components/date-picker2/__docs__/demo/format/index.tsx
@@ -37,6 +37,9 @@ function App() {
             <div>
                 <DatePicker2 defaultValue={defaultVal} format={customizeFormatter} />
             </div>
+            <div>
+                <DatePicker2 defaultValue={defaultVal} format="MMM D, YYYY" />
+            </div>
         </div>
     );
 }

--- a/components/date-picker2/__tests__/index-spec.js
+++ b/components/date-picker2/__tests__/index-spec.js
@@ -8,6 +8,8 @@ import dayjs from 'dayjs';
 import co from 'co';
 import moment from 'moment';
 import DatePicker from '../index';
+import { ConfigProvider } from '@alifd/next';
+import en from '@alifd/next/lib/locale/en-us';
 import Form from '../../form/index';
 import Field from '../../field/index';
 import { DATE_PICKER_MODE } from '../constant';
@@ -1142,6 +1144,17 @@ describe('Picker', () => {
                 assert(typeof inputProps.onInputTypeChange === 'function');
                 return <div>test</div>
             }} />);
+        })
+
+        // fix https://github.com/alibaba-fusion/next/issues/4788
+        it('The English translation does not comply with international standards', () => {
+            wrapper = mount(
+                <ConfigProvider locale={en}>
+                    <DatePicker defaultValue="2020-02-02" format="MMM D, YYYY" defaultVisible />
+                </ConfigProvider>
+            );
+            assert(getStrValue() === 'Feb 2, 2020');
+            assert(wrapper.find(`.next-calendar2-header-text-field`).text() === `Feb2020`);
         })
     });
 });

--- a/components/locale/en-us.ts
+++ b/components/locale/en-us.ts
@@ -45,6 +45,7 @@ const locale: Locale = {
         hour: 'H',
         minute: 'M',
         second: 'S',
+        monthBeforeYear: true,
     },
     Dialog: {
         close: 'Close',

--- a/components/locale/types.ts
+++ b/components/locale/types.ts
@@ -53,6 +53,7 @@ export interface Locale extends LocaleConfig {
         hour: string;
         minute: string;
         second: string;
+        monthBeforeYear?: boolean;
     };
     Dialog: Partial<{
         close: string;


### PR DESCRIPTION
修复DatePicker2英文翻译不符合国际化规范，新增format示例：英文翻译后更符合国际化规范
![image](https://github.com/alibaba-fusion/next/assets/92377270/078f065c-1292-49a2-bc9f-3856be59f22b)
close #4788 