### PR TITLE
fix(Core): 修复使用 css variable 模式构建时，主题包内的 varMap 配置值会被重复覆盖的问题

### DIFF
--- a/components/core/util/_varMap.scss
+++ b/components/core/util/_varMap.scss
@@ -1,4 +1,4 @@
-$varMap: ();
+$varMap: () !default;
 @function get-compiling-value($cssVarRepresentation) {
     @if map-has-key($varMap, $cssVarRepresentation) {
         @return map-get($varMap, $cssVarRepresentation);


### PR DESCRIPTION
如题，构建工具使用sass-loader 配置 additionalData 引入主题包内的 variables.scss2css.scss 文件进行编译时， 该文件的 varMap 赋值会被scss 文件内的顶部的 @import "..../core/util/_varMap" 覆盖，导致编译异常。
错误提示大致如下：
![image](https://github.com/user-attachments/assets/2a3d6eb8-8ca2-49d4-87ad-9695bb70f06c)
