### PR TITLE
fix(TimePicker2):  support set locale by ConfigProvider

### DIFF
--- a/components/time-picker2/__tests__/index-spec.tsx
+++ b/components/time-picker2/__tests__/index-spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import dayjs, { type Dayjs } from 'dayjs';
 import TimePicker2, { type TimePickerProps } from '../index';
+import ConfigProvider from '../../config-provider';
+import enUS from '../../locale/en-us';
 import '../../time-picker/style';
 
 const defaultValue = dayjs('11:12:13', 'HH:mm:ss', true);
@@ -282,6 +284,16 @@ describe('TimePicker2', () => {
 
             cy.get(timeInput).type('{ctrl+downarrow}', { force: true });
             cy.get(timeInput).should('have.value', '00:00:00');
+        });
+
+        it('should can set locale by ConfigProvider', () => {
+            cy.mount(
+                <ConfigProvider locale={enUS}>
+                    <TimePicker2 />
+                </ConfigProvider>
+            );
+            const timeInput = '.next-time-picker2-input input';
+            cy.get(timeInput).should('have.attr', 'placeholder', enUS.TimePicker.placeholder);
         });
     });
 

--- a/components/time-picker2/index.tsx
+++ b/components/time-picker2/index.tsx
@@ -7,7 +7,7 @@ import type { TimePickerProps, ValueType, RangePickerProps, PresetType } from '.
 
 const ConfigTimePicker = ConfigProvider.config(TimePicker);
 
-const TimePickerWithSub = assignSubComponent(TimePicker, {
+const TimePickerWithSub = assignSubComponent(ConfigTimePicker, {
     RangePicker: React.forwardRef(
         (props: TimePickerProps, ref: LegacyRef<ComponentRef<typeof ConfigTimePicker>>) => (
             <ConfigTimePicker ref={ref} {...props} type="range" />


### PR DESCRIPTION
TimePicker2 在透出的时候 assignSubComponent 方法没有用ConfigProvider包裹的TimePicker2，导致ConfigProvider 设置 locale时，TimePicker2不生效