### PR TITLE
Form.Item 支持 rowSpan & 修复 ResponsiveGrid 生成属性错误

### DIFF
--- a/components/form/item.tsx
+++ b/components/form/item.tsx
@@ -62,6 +62,7 @@ export default class Item extends Component<ItemProps> {
         device: PropTypes.oneOf(['phone', 'tablet', 'desktop']),
         responsive: PropTypes.bool,
         colSpan: PropTypes.number,
+        rowSpan: PropTypes.number,
         labelWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         isPreview: PropTypes.bool,
         renderPreview: PropTypes.func,

--- a/components/form/types.ts
+++ b/components/form/types.ts
@@ -279,6 +279,12 @@ export interface ItemProps extends HTMLAttributes<HTMLElement>, CommonProps {
     colSpan?: number;
 
     /**
+     * 在响应式布局模式下，表单项占多少行
+     * @en in response layout mode, how many rows does the form item occupy
+     */
+    rowSpan?: number;
+
+    /**
      * 在响应式布局下，且 label 在左边时，label 的宽度是多少
      * @en in response layout mode, and the label is on the left, how wide is the label
      * @defaultValue 100

--- a/components/responsive-grid/create-style.ts
+++ b/components/responsive-grid/create-style.ts
@@ -167,7 +167,7 @@ const getGridChildProps = (
     device: ResponsiveGridProps['device'],
     gap?: ResponsiveGridProps['gap']
 ) => {
-    const { row = 'initial', col = 'initial', rowSpan = 1, colSpan = 1 } = props;
+    const { row = 'auto', col = 'auto', rowSpan = 1, colSpan = 1 } = props;
 
     let totalSpan = 12;
     let newColSpan =


### PR DESCRIPTION
1. 表单Item在 responsive 模式下支持配置 rowSpan ，完善类型
2. 修复 ResponsiveGrid 生成 grid-row-start 和 grid-column-start 属性错误默认值问题，由 initial -> auto