### PR TITLE
fix(*): 优化各类 Option 对象的类型兼容问题

### DIFF
--- a/components/cascader/__docs__/index.en-us.md
+++ b/components/cascader/__docs__/index.en-us.md
@@ -52,7 +52,7 @@ export type CascaderDataItem = {
     checkboxDisabled?: boolean;
     children?: Array<CascaderDataItem>;
     title?: string;
-    [propName: string]: unknown;
+    [propName: string]: any;
 };
 ```
 

--- a/components/cascader/__docs__/index.md
+++ b/components/cascader/__docs__/index.md
@@ -54,7 +54,7 @@ export type CascaderDataItem = {
     checkboxDisabled?: boolean;
     children?: Array<CascaderDataItem>;
     title?: string;
-    [propName: string]: unknown;
+    [propName: string]: any;
 };
 ```
 

--- a/components/cascader/types.ts
+++ b/components/cascader/types.ts
@@ -14,7 +14,7 @@ export type CascaderDataItem = {
     checkboxDisabled?: boolean;
     children?: Array<CascaderDataItem>;
     title?: string;
-    [propName: string]: unknown;
+    [propName: string]: any;
 };
 
 /**

--- a/components/checkbox/__docs__/index.en-us.md
+++ b/components/checkbox/__docs__/index.en-us.md
@@ -68,7 +68,7 @@ export type CheckboxData = {
     value: ValueItem;
     label?: React.ReactNode;
     disabled?: boolean;
-    [propName: string]: unknown;
+    [propName: string]: any;
 };
 ```
 

--- a/components/checkbox/__docs__/index.md
+++ b/components/checkbox/__docs__/index.md
@@ -68,7 +68,7 @@ export type CheckboxData = {
     value: ValueItem;
     label?: React.ReactNode;
     disabled?: boolean;
-    [propName: string]: unknown;
+    [propName: string]: any;
 };
 ```
 

--- a/components/checkbox/types.ts
+++ b/components/checkbox/types.ts
@@ -16,7 +16,7 @@ export type CheckboxData = {
     value: ValueItem;
     label?: React.ReactNode;
     disabled?: boolean;
-    [propName: string]: unknown;
+    [propName: string]: any;
 };
 
 /**

--- a/components/collapse/__docs__/index.en-us.md
+++ b/components/collapse/__docs__/index.en-us.md
@@ -51,7 +51,7 @@ export type DataItem = {
     disabled?: boolean;
     key?: KeyType;
     onClick?: (key: KeyType) => void;
-    [propName: string]: unknown;
+    [propName: string]: any;
 };
 ```
 

--- a/components/collapse/__docs__/index.md
+++ b/components/collapse/__docs__/index.md
@@ -53,7 +53,7 @@ export type DataItem = {
     disabled?: boolean;
     key?: KeyType;
     onClick?: (key: KeyType) => void;
-    [propName: string]: unknown;
+    [propName: string]: any;
 };
 ```
 

--- a/components/collapse/types.ts
+++ b/components/collapse/types.ts
@@ -50,7 +50,7 @@ export type DataItem = {
     disabled?: boolean;
     key?: KeyType;
     onClick?: (key: KeyType) => void;
-    [propName: string]: unknown;
+    [propName: string]: any;
 };
 
 /**

--- a/components/demo-helper/index.tsx
+++ b/components/demo-helper/index.tsx
@@ -8,7 +8,7 @@ interface DemoItem {
     hidden?: boolean;
     exists?: boolean;
     title?: string;
-    [key: string]: unknown;
+    [key: string]: any;
 }
 
 type ShowType = 'none' | 'hidden';

--- a/components/responsive-grid/types.ts
+++ b/components/responsive-grid/types.ts
@@ -2,7 +2,7 @@ import type { HTMLAttributes } from 'react';
 import type * as CSS from 'csstype';
 import type { CommonProps } from '../util';
 
-export type ObjectType = { [key: string]: unknown };
+export type ObjectType = { [key: string]: any };
 export type Spacing =
     | number
     | [topAndRightAndBottomAndLeft: number]

--- a/components/select/types.ts
+++ b/components/select/types.ts
@@ -58,7 +58,7 @@ export interface ObjectItem {
      * @skip
      */
     __isAddon?: boolean;
-    [propName: string]: unknown;
+    [propName: string]: any;
 }
 
 export interface NormalizedObjectItem extends ObjectItem {

--- a/components/transfer/__docs__/index.en-us.md
+++ b/components/transfer/__docs__/index.en-us.md
@@ -57,7 +57,7 @@ export type TransferDataItem = {
     title?: string;
     disabled?: boolean;
     children?: TransferDataItem[];
-    [key: string]: unknown;
+    [key: string]: any;
 };
 ```
 

--- a/components/transfer/types.ts
+++ b/components/transfer/types.ts
@@ -14,7 +14,7 @@ export type TransferDataItem = {
     title?: string;
     disabled?: boolean;
     children?: TransferDataItem[];
-    [key: string]: unknown;
+    [key: string]: any;
 };
 /**
  * @api PositionType

--- a/components/tree-select/tree-select.tsx
+++ b/components/tree-select/tree-select.tsx
@@ -924,7 +924,7 @@ class TreeSelect extends Component<TreeSelectProps, TreeSelectState> {
 
         let data: ObjectItem[] | ObjectItem = this.getData(valueForSelect, true);
         if (!multiple && !treeCheckable) {
-            data = data[0];
+            data = Array.isArray(data) ? data[0] : data;
         }
 
         if (isPreview) {


### PR DESCRIPTION
各类可传入 Option 对象的组件，如 Select
在如下方式使用时，会提示 dataSource 类型不兼容问题
```tsx
interface IOptionItem {
  label: string;
  value: string;
}

const dataSource: IOptionItem[] = [
  { label: 'Opt1', value: '1' },
  { label: 'Opt2', value: '2' },
];
<Select dataSource={dataSource} />
```
<img width="1446" height="432" alt="image" src="https://github.com/user-attachments/assets/eb36a220-3792-4771-b875-f256a77fb77a" />

通过调整 Option 类型的签名类型为下列方式解决
```diff
interface DataSourceItem {
  // ...
-  [key: string]: unknown;
+  [key: string]: any;
}

```