### PR TITLE
fix(TreeSelect): fix expandedKeys bug when search by searchValue is e…

### DIFF
--- a/components/tree-select/__tests__/index-spec.tsx
+++ b/components/tree-select/__tests__/index-spec.tsx
@@ -929,6 +929,28 @@ describe('TreeSelect', () => {
         cy.contains('.next-select-values', '服装/男装');
     });
 
+    it('should expandedAll when search by searchValue is empty and treeDefaultExpandAll is true', () => {
+        const searchedValue = '外套';
+        const handleSearch = cy.spy();
+
+        cy.mount(
+            <TreeSelect
+                defaultVisible
+                treeDefaultExpandAll
+                dataSource={dataSource}
+                showSearch
+                onSearch={debounce(handleSearch, 20)} // Debounce for simulate Cypress action type below
+            />
+        );
+        cy.get('.next-select-trigger-search input').type(searchedValue);
+        cy.get('.next-tree-node').then($el => {
+            const list = $el.filter('[style!="display: none;"]');
+            cy.wrap(list).should('have.length', 3);
+        });
+        cy.get('.next-select-trigger-search input').clear();
+        cy.get('.next-tree-node').should('have.length', 6);
+    });
+
     describe('should support useDetailValue', () => {
         it('Support dataSource mode', () => {
             const handleChange = cy.spy();

--- a/components/tree-select/tree-select.tsx
+++ b/components/tree-select/tree-select.tsx
@@ -774,6 +774,12 @@ class TreeSelect extends Component<TreeSelectProps, TreeSelectState> {
                 notFound = true;
             }
         } else {
+            // 如过 filterLocal 并且 showSearch 但是没有 searchedValue 的时候，也需要设置 expandedKeys
+            if (filterLocal && showSearch) {
+                treeProps.expandedKeys = expandedKeys;
+                treeProps.autoExpandParent = autoExpandParent;
+                treeProps.onExpand = this.handleExpand;
+            }
             // eslint-disable-next-line
             if (dataSource) {
                 if (dataSource.length) {


### PR DESCRIPTION
在搜索清空了之后，expandedKeys 字段还是保持的之前存在搜索内容时的值，导致了列表搜索条件结果和原来保持一致。理论上应该在此时展示全部内容。