### PR TITLE
fix(Drawer): ensure correct padding-right is applied to body when Drawer is opened with scroll

### DIFF
--- a/components/drawer/__tests__/index-v2-spec.tsx
+++ b/components/drawer/__tests__/index-v2-spec.tsx
@@ -105,4 +105,46 @@ describe('Drawer v2', () => {
             hide();
         });
     });
+    it('should add paddingRight to body when body is scroll on open Drawer', () => {
+        let tallDiv: HTMLDivElement;
+
+        // 创建一个高元素使 body 产生滚动条
+        cy.document().then(doc => {
+            tallDiv = doc.createElement('div');
+            tallDiv.style.height = '110vh';
+            tallDiv.setAttribute('data-test-element', 'scroll-trigger'); // 添加标识方便查找
+            doc.body.appendChild(tallDiv);
+        });
+
+        // 设置初始 padding-right
+        cy.get('body').invoke('css', 'padding-right', '10px');
+        cy.get('body').invoke('css', 'overflow', 'auto');
+
+        cy.mount(
+            <Drawer v2 visible title="test" closeMode={[]}>
+                body
+            </Drawer>
+        );
+
+        cy.then(() => {
+            const scrollDiv = document.createElement('div');
+            scrollDiv.className = 'just-to-get-scrollbar-size';
+            scrollDiv.style.width = '100px';
+            scrollDiv.style.height = '100px';
+            scrollDiv.style.overflow = 'scroll';
+            scrollDiv.style.position = 'absolute';
+            scrollDiv.style.top = '-9999px';
+            document.body.appendChild(scrollDiv);
+            const scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
+            document.body.removeChild(scrollDiv);
+            cy.get('body').should('have.css', 'padding-right', `${10 + scrollbarWidth}px`);
+        });
+
+        // 清理添加的元素
+        cy.then(() => {
+            if (tallDiv && tallDiv.parentNode) {
+                tallDiv.parentNode.removeChild(tallDiv);
+            }
+        });
+    });
 });

--- a/components/drawer/drawer-v2.tsx
+++ b/components/drawer/drawer-v2.tsx
@@ -145,7 +145,7 @@ const Drawer = (props: DrawerV2Props) => {
                 const scrollWidth = dom.scrollbar().width;
                 if (scrollWidth) {
                     style.paddingRight = `${
-                        dom.getStyle(document.body, 'paddingRight').toString() +
+                        (dom.getStyle(document.body, 'paddingRight') as number) +
                         dom.scrollbar().width
                     }px`;
                 }


### PR DESCRIPTION
修复当body内容滚动，且有padding-right样式时，抽屉显示后给body增加了一个错误的padding-right样式的问题。